### PR TITLE
[DM-32386] Fix time handling for job creation, start, end

### DIFF
--- a/src/vocutouts/uws/jobs.py
+++ b/src/vocutouts/uws/jobs.py
@@ -72,7 +72,7 @@ def uws_job_started(
     """
     storage = WorkerJobStore(session)
     try:
-        storage.start_executing(job_id, message_id)
+        storage.start_executing(job_id, message_id, start_time)
     except UnknownJobError:
         pass
 


### PR DESCRIPTION
The way timezones were handled wasn't entirely correct, and we
were therefore storing local times in the database and not using
the start time passed to the database worker.  Ensure that we store
UTC everywhere and use the start time we determined.