### PR TITLE
[DM-33604] Stop using if TYPE_CHECKING

### DIFF
--- a/src/vocutouts/actors.py
+++ b/src/vocutouts/actors.py
@@ -34,7 +34,7 @@ always appear to be `None` because the import won't pick up changes from the
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List
 
 import dramatiq
 import structlog
@@ -43,9 +43,6 @@ from . import broker
 from .config import config
 from .uws.jobs import uws_job_completed, uws_job_failed, uws_job_started
 from .uws.utils import parse_isodatetime
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List
 
 __all__ = [
     "cutout",

--- a/src/vocutouts/broker.py
+++ b/src/vocutouts/broker.py
@@ -11,24 +11,19 @@ or those tasks will be associated with a RabbitMQ broker.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Optional
 
 import dramatiq
 import structlog
-from dramatiq import Middleware
+from dramatiq import Broker, Middleware, Worker
 from dramatiq.brokers.redis import RedisBroker
 from dramatiq.middleware import CurrentMessage
 from dramatiq.results import Results
 from dramatiq.results.backends import RedisBackend
+from sqlalchemy.orm import scoped_session
 
 from .config import config
 from .uws.database import create_sync_session
-
-if TYPE_CHECKING:
-    from typing import Optional
-
-    from dramatiq import Broker, Worker
-    from sqlalchemy.orm import scoped_session
 
 broker = RedisBroker(host=config.redis_host, password=config.redis_password)
 """Broker used by UWS."""

--- a/src/vocutouts/cli.py
+++ b/src/vocutouts/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import Any, Awaitable, Callable, Optional, TypeVar
 
 import click
 import structlog
@@ -13,10 +13,7 @@ import uvicorn
 from .config import config
 from .uws.database import initialize_database
 
-if TYPE_CHECKING:
-    from typing import Any, Awaitable, Callable, Optional, TypeVar
-
-    T = TypeVar("T")
+T = TypeVar("T")
 
 
 def coroutine(f: Callable[..., Awaitable[T]]) -> Callable[..., T]:

--- a/src/vocutouts/config.py
+++ b/src/vocutouts/config.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Optional
 
 from .uws.config import UWSConfig
-
-if TYPE_CHECKING:
-    from typing import Optional
 
 __all__ = ["Configuration", "config"]
 

--- a/src/vocutouts/exceptions.py
+++ b/src/vocutouts/exceptions.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import List
 
 from .uws.exceptions import ParameterError
-
-if TYPE_CHECKING:
-    from typing import List
-
-    from .uws.models import JobParameter
+from .uws.models import JobParameter
 
 __all__ = ["InvalidCutoutParameterError"]
 

--- a/src/vocutouts/models/parameters.py
+++ b/src/vocutouts/models/parameters.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import List
 
 from ..exceptions import InvalidCutoutParameterError
-from .stencils import parse_stencil
-
-if TYPE_CHECKING:
-    from typing import List
-
-    from .models.stencils import Stencil
-    from .uws.models import JobParameter
+from ..uws.models import JobParameter
+from .stencils import Stencil, parse_stencil
 
 
 @dataclass

--- a/src/vocutouts/models/stencils.py
+++ b/src/vocutouts/models/stencils.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Any, Dict, Tuple
 
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 
-if TYPE_CHECKING:
-    from typing import Any, Dict, Tuple
-
-    Range = Tuple[float, float]
+Range = Tuple[float, float]
 
 
 class Stencil(ABC):

--- a/src/vocutouts/policy.py
+++ b/src/vocutouts/policy.py
@@ -2,23 +2,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import List
+
+from dramatiq import Actor, Message
+from structlog.stdlib import BoundLogger
 
 from .actors import job_completed, job_failed
 from .exceptions import InvalidCutoutParameterError
 from .models.parameters import CutoutParameters
 from .models.stencils import RangeStencil
 from .uws.exceptions import MultiValuedParameterError, ParameterError
+from .uws.models import Job, JobParameter
 from .uws.policy import UWSPolicy
-
-if TYPE_CHECKING:
-    from datetime import datetime
-    from typing import List
-
-    from dramatiq import Actor, Message
-    from structlog.stdlib import BoundLogger
-
-    from .uws.models import Job, JobParameter
 
 __all__ = ["ImageCutoutPolicy"]
 

--- a/src/vocutouts/uws/config.py
+++ b/src/vocutouts/uws/config.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Optional
+from typing import Optional
 
 __all__ = ["UWSConfig"]
 

--- a/src/vocutouts/uws/database.py
+++ b/src/vocutouts/uws/database.py
@@ -20,25 +20,21 @@ from __future__ import annotations
 
 import time
 from asyncio import current_task
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
     AsyncSession,
     async_scoped_session,
     create_async_engine,
 )
 from sqlalchemy.orm import scoped_session, sessionmaker
+from structlog.stdlib import BoundLogger
 
+from .config import UWSConfig
 from .schema import Job, drop_schema, initialize_schema
-
-if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncEngine
-    from structlog.stdlib import BoundLogger
-
-    from .config import UWSConfig
 
 __all__ = [
     "create_async_session",

--- a/src/vocutouts/uws/errors.py
+++ b/src/vocutouts/uws/errors.py
@@ -7,15 +7,11 @@ may be a better choice, but revision 1.0 of the SODA standard only allows
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import PlainTextResponse
 
 from .exceptions import UWSError
-
-if TYPE_CHECKING:
-    from fastapi import FastAPI, Request
 
 __all__ = ["install_error_handlers"]
 

--- a/src/vocutouts/uws/exceptions.py
+++ b/src/vocutouts/uws/exceptions.py
@@ -6,12 +6,9 @@ The types of exceptions here control the error handling behavior configured in
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Dict, Optional
 
 from .models import ErrorCode, ErrorType, JobError
-
-if TYPE_CHECKING:
-    from typing import Dict, Optional
 
 __all__ = [
     "DataMissingError",

--- a/src/vocutouts/uws/jobs.py
+++ b/src/vocutouts/uws/jobs.py
@@ -29,17 +29,14 @@ or receive their own infrastructure objects.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List
+
+from sqlalchemy.orm import scoped_session
+from structlog.stdlib import BoundLogger
 
 from .exceptions import TaskError, UnknownJobError
 from .models import JobResult
 from .storage import WorkerJobStore
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List
-
-    from sqlalchemy.orm import scoped_session
-    from structlog.stdlib import BoundLogger
 
 __all__ = [
     "uws_job_started",

--- a/src/vocutouts/uws/models.py
+++ b/src/vocutouts/uws/models.py
@@ -9,10 +9,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 
 @dataclass

--- a/src/vocutouts/uws/policy.py
+++ b/src/vocutouts/uws/policy.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import List
 
-if TYPE_CHECKING:
-    from datetime import datetime
-    from typing import List
+from dramatiq import Message
 
-    from dramatiq import Message
-
-    from .models import Job, JobParameter
+from .models import Job, JobParameter
 
 __all__ = ["UWSPolicy"]
 

--- a/src/vocutouts/uws/responses.py
+++ b/src/vocutouts/uws/responses.py
@@ -3,19 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import List
 
+from fastapi import Request, Response
 from fastapi.templating import Jinja2Templates
 
+from .models import Availability, Job, JobDescription, JobError
+from .results import ResultStore
 from .utils import isodatetime
-
-if TYPE_CHECKING:
-    from typing import List
-
-    from fastapi import Request, Response
-
-    from .models import Availability, Job, JobDescription, JobError
-    from .results import ResultStore
 
 __all__ = ["UWSTemplates"]
 

--- a/src/vocutouts/uws/results.py
+++ b/src/vocutouts/uws/results.py
@@ -8,18 +8,14 @@ URL to a signed URL suitable for returning to a client of the service.
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import google.auth
 from google.auth import impersonated_credentials
 from google.cloud import storage
 
-from .models import JobResultURL
-
-if TYPE_CHECKING:
-    from .config import UWSConfig
-    from .models import JobResult
+from .config import UWSConfig
+from .models import JobResult, JobResultURL
 
 __all__ = ["ResultStore"]
 

--- a/src/vocutouts/uws/schema/__init__.py
+++ b/src/vocutouts/uws/schema/__init__.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from .base import Base
 from .job import Job
 from .job_parameter import JobParameter
 from .job_result import JobResult
-
-if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncEngine
 
 __all__ = [
     "Job",

--- a/src/vocutouts/uws/schema/job.py
+++ b/src/vocutouts/uws/schema/job.py
@@ -8,20 +8,16 @@ and sharp edges.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import List, Optional
 
 from sqlalchemy import Column, DateTime, Enum, Index, Integer, String, Text
 from sqlalchemy.orm import relationship
 
 from ..models import ErrorCode, ErrorType, ExecutionPhase
 from .base import Base
-
-if TYPE_CHECKING:
-    from datetime import datetime
-    from typing import List, Optional
-
-    from .job_parameter import JobParameter
-    from .job_result import JobResult
+from .job_parameter import JobParameter
+from .job_result import JobResult
 
 __all__ = ["Job"]
 

--- a/src/vocutouts/uws/schema/job_result.py
+++ b/src/vocutouts/uws/schema/job_result.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Optional
 
 from sqlalchemy import Column, ForeignKey, Index, Integer, String
 
 from .base import Base
-
-if TYPE_CHECKING:
-    from typing import Optional
 
 __all__ = ["JobResult"]
 

--- a/src/vocutouts/uws/service.py
+++ b/src/vocutouts/uws/service.py
@@ -4,20 +4,22 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import List, Optional
 
+from dramatiq import Message
+
+from .config import UWSConfig
 from .exceptions import InvalidPhaseError, PermissionDeniedError
-from .models import ACTIVE_PHASES, ExecutionPhase
-
-if TYPE_CHECKING:
-    from typing import List, Optional
-
-    from dramatiq import Message
-
-    from .config import UWSConfig
-    from .models import Availability, Job, JobDescription, JobParameter
-    from .policy import UWSPolicy
-    from .storage import FrontendJobStore
+from .models import (
+    ACTIVE_PHASES,
+    Availability,
+    ExecutionPhase,
+    Job,
+    JobDescription,
+    JobParameter,
+)
+from .policy import UWSPolicy
+from .storage import FrontendJobStore
 
 __all__ = ["JobService"]
 

--- a/src/vocutouts/uws/storage.py
+++ b/src/vocutouts/uws/storage.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 from typing import (
-    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
+    List,
+    Optional,
     TypeVar,
     cast,
     overload,
@@ -17,7 +18,9 @@ from typing import (
 from asyncpg.exceptions import SerializationError
 from sqlalchemy import delete
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.future import select
+from sqlalchemy.orm import scoped_session
 
 from .exceptions import UnknownJobError
 from .models import (
@@ -32,12 +35,6 @@ from .models import (
 from .schema.job import Job as SQLJob
 from .schema.job_parameter import JobParameter as SQLJobParameter
 from .schema.job_result import JobResult as SQLJobResult
-
-if TYPE_CHECKING:
-    from typing import List, Optional
-
-    from sqlalchemy.ext.asyncio import async_scoped_session
-    from sqlalchemy.orm import scoped_session
 
 F = TypeVar("F", bound=Callable[..., Any])
 G = TypeVar("G", bound=Callable[..., Awaitable[Any]])

--- a/src/vocutouts/uws/utils.py
+++ b/src/vocutouts/uws/utils.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import Optional
+from typing import Optional
 
 
 def isodatetime(timestamp: datetime) -> str:

--- a/src/vocutouts/workers.py
+++ b/src/vocutouts/workers.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -34,9 +34,6 @@ from lsst.image_cutout_backend.stencils import (
     SkyPolygon,
     SkyStencil,
 )
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List
 
 redis_host = os.environ["CUTOUT_REDIS_HOST"]
 redis_password = os.getenv("CUTOUT_REDIS_PASSWORD")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import Any, AsyncIterator, Dict, Iterator, List
 
 import dramatiq
 import pytest
@@ -11,6 +11,7 @@ import pytest_asyncio
 import structlog
 from asgi_lifespan import LifespanManager
 from dramatiq.middleware import CurrentMessage
+from fastapi import FastAPI
 from httpx import AsyncClient
 
 from vocutouts import main
@@ -23,11 +24,6 @@ from vocutouts.uws.dependencies import uws_dependency
 from vocutouts.uws.utils import isodatetime
 
 from .support.uws import mock_uws_google_storage
-
-if TYPE_CHECKING:
-    from typing import Any, AsyncIterator, Dict, Iterator, List
-
-    from fastapi import FastAPI
 
 
 @dramatiq.actor(queue_name="cutout", store_results=True)

--- a/tests/handlers/async_test.py
+++ b/tests/handlers/async_test.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import Dict, List
 
 import pytest
 from dramatiq import Worker
+from httpx import AsyncClient
 
 from vocutouts.broker import broker
-
-if TYPE_CHECKING:
-    from typing import Dict, List
-
-    from httpx import AsyncClient
-
 
 PENDING_JOB = """
 <uws:job

--- a/tests/handlers/error_test.py
+++ b/tests/handlers/error_test.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from dramatiq import Worker
+from httpx import AsyncClient
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -13,9 +12,6 @@ from vocutouts.broker import broker
 from vocutouts.config import config
 from vocutouts.uws.database import _build_database_url
 from vocutouts.uws.schema import drop_schema
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from vocutouts.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 AVAILABILITY = """
 <vosi:availability xmlns:vosi="http://www.ivoa.net/xml/VOSIAvailability/v1.0">

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from vocutouts.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/sync_test.py
+++ b/tests/handlers/sync_test.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Dict, List
 
 import pytest
 from dramatiq import Worker
+from httpx import AsyncClient
 
 from vocutouts.broker import broker
-
-if TYPE_CHECKING:
-    from typing import Dict, List
-
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/tests/support/uws.py
+++ b/tests/support/uws.py
@@ -6,17 +6,19 @@ import asyncio
 import os
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
 from unittest.mock import Mock, patch
 
 import dramatiq
 import structlog
-from dramatiq import Actor, Message
+from dramatiq import Actor, Broker, Message, Worker
 from dramatiq.brokers.stub import StubBroker
 from dramatiq.middleware import CurrentMessage, Middleware
 from dramatiq.results import Results
 from dramatiq.results.backends import StubBackend
 from google.cloud import storage
+from sqlalchemy.orm import scoped_session
 
 from vocutouts.uws.config import UWSConfig
 from vocutouts.uws.database import create_sync_session
@@ -25,19 +27,10 @@ from vocutouts.uws.jobs import (
     uws_job_failed,
     uws_job_started,
 )
-from vocutouts.uws.models import ExecutionPhase
+from vocutouts.uws.models import ExecutionPhase, Job, JobParameter
 from vocutouts.uws.policy import UWSPolicy
+from vocutouts.uws.service import JobService
 from vocutouts.uws.utils import isodatetime, parse_isodatetime
-
-if TYPE_CHECKING:
-    from pathlib import Path
-    from typing import Any, Dict, Iterator, List, Optional
-
-    from dramatiq import Broker, Worker
-    from sqlalchemy.orm import scoped_session
-
-    from vocutouts.uws.models import Job, JobParameter
-    from vocutouts.uws.service import JobService
 
 SOURCE_UUID = str(uuid.uuid4())
 """UUID of the source for a cutout."""

--- a/tests/uws/conftest.py
+++ b/tests/uws/conftest.py
@@ -11,16 +11,21 @@ to Safir.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
 import structlog
 from asgi_lifespan import LifespanManager
+from dramatiq import Broker
 from fastapi import FastAPI
 from httpx import AsyncClient
 from safir.dependencies.http_client import http_client_dependency
+from sqlalchemy.ext.asyncio import async_scoped_session
+from structlog.stdlib import BoundLogger
 
+from vocutouts.uws.config import UWSConfig
 from vocutouts.uws.database import create_async_session, initialize_database
 from vocutouts.uws.dependencies import UWSFactory, uws_dependency
 from vocutouts.uws.errors import install_error_handlers
@@ -35,16 +40,6 @@ from ..support.uws import (
     trivial_job,
     uws_broker,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
-    from typing import AsyncIterator, Iterator
-
-    from dramatiq import Broker
-    from sqlalchemy.ext.asyncio import async_scoped_session
-    from structlog.stdlib import BoundLogger
-
-    from vocutouts.uws.config import UWSConfig
 
 
 @pytest_asyncio.fixture

--- a/tests/uws/errors_test.py
+++ b/tests/uws/errors_test.py
@@ -3,18 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Dict
 
 import pytest
+from httpx import AsyncClient
 
+from vocutouts.uws.dependencies import UWSFactory
 from vocutouts.uws.models import JobParameter
-
-if TYPE_CHECKING:
-    from typing import Dict
-
-    from httpx import AsyncClient
-
-    from vocutouts.uws.dependencies import UWSFactory
 
 
 @dataclass

--- a/tests/uws/job_api_test.py
+++ b/tests/uws/job_api_test.py
@@ -7,22 +7,17 @@ API to create a job, instead inserting it directly via the UWSService.
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
 
 import pytest
 from dramatiq import Worker
+from httpx import AsyncClient
+from structlog.stdlib import BoundLogger
 
 from tests.support.uws import uws_broker, wait_for_job
+from vocutouts.uws.config import UWSConfig
+from vocutouts.uws.dependencies import UWSFactory
 from vocutouts.uws.models import JobParameter
 from vocutouts.uws.utils import isodatetime
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
-    from structlog.stdlib import BoundLogger
-
-    from vocutouts.uws.config import UWSConfig
-    from vocutouts.uws.dependencies import UWSFactory
-
 
 PENDING_JOB = """
 <uws:job

--- a/tests/uws/job_error_test.py
+++ b/tests/uws/job_error_test.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List
 
 import dramatiq
 import pytest
 from dramatiq import Worker
 from dramatiq.middleware import CurrentMessage
+from httpx import AsyncClient
+from structlog.stdlib import BoundLogger
 
 from tests.support.uws import (
     TrivialPolicy,
@@ -17,20 +19,11 @@ from tests.support.uws import (
     uws_broker,
     wait_for_job,
 )
-from vocutouts.uws.dependencies import uws_dependency
+from vocutouts.uws.config import UWSConfig
+from vocutouts.uws.dependencies import UWSFactory, uws_dependency
 from vocutouts.uws.exceptions import TaskFatalError, TaskTransientError
 from vocutouts.uws.models import ErrorCode, JobParameter
 from vocutouts.uws.utils import isodatetime
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List
-
-    from httpx import AsyncClient
-    from structlog.stdlib import BoundLogger
-
-    from vocutouts.uws.config import UWSConfig
-    from vocutouts.uws.dependencies import UWSFactory
-
 
 ERRORED_JOB = """
 <uws:job

--- a/tests/uws/job_list_test.py
+++ b/tests/uws/job_list_test.py
@@ -7,21 +7,16 @@ API to create a job, instead inserting it directly via the UWSService.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy import update
+from sqlalchemy.ext.asyncio import async_scoped_session
 
+from vocutouts.uws.dependencies import UWSFactory
 from vocutouts.uws.models import JobParameter
 from vocutouts.uws.schema import Job as SQLJob
 from vocutouts.uws.utils import isodatetime
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
-    from sqlalchemy.ext.asyncio import async_scoped_session
-
-    from vocutouts.uws.dependencies import UWSFactory
-
 
 FULL_JOB_LIST = """
 <uws:jobs

--- a/tests/uws/long_polling_test.py
+++ b/tests/uws/long_polling_test.py
@@ -4,27 +4,20 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List
 
 import dramatiq
 import pytest
 from dramatiq import Worker
 from dramatiq.middleware import CurrentMessage
+from httpx import AsyncClient
+from structlog.stdlib import BoundLogger
 
 from tests.support.uws import TrivialPolicy, job_started, uws_broker
-from vocutouts.uws.dependencies import uws_dependency
+from vocutouts.uws.config import UWSConfig
+from vocutouts.uws.dependencies import UWSFactory, uws_dependency
 from vocutouts.uws.models import JobParameter
 from vocutouts.uws.utils import isodatetime
-
-if TYPE_CHECKING:
-    from typing import Any, Dict, List
-
-    from httpx import AsyncClient
-    from structlog.stdlib import BoundLogger
-
-    from vocutouts.uws.config import UWSConfig
-    from vocutouts.uws.dependencies import UWSFactory
-
 
 PENDING_JOB = """
 <uws:job

--- a/tests/uws/policy_test.py
+++ b/tests/uws/policy_test.py
@@ -3,24 +3,17 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import List
 
 import pytest
+from httpx import AsyncClient
 
 from tests.support.uws import TrivialPolicy
-from vocutouts.uws.dependencies import uws_dependency
+from vocutouts.uws.config import UWSConfig
+from vocutouts.uws.dependencies import UWSFactory, uws_dependency
 from vocutouts.uws.exceptions import ParameterError
-from vocutouts.uws.models import JobParameter
+from vocutouts.uws.models import Job, JobParameter
 from vocutouts.uws.utils import isodatetime
-
-if TYPE_CHECKING:
-    from typing import List
-
-    from httpx import AsyncClient
-
-    from vocutouts.uws.config import UWSConfig
-    from vocutouts.uws.dependencies import UWSFactory
-    from vocutouts.uws.models import Job
 
 
 class Policy(TrivialPolicy):


### PR DESCRIPTION
if TYPE_CHECKING tends to hide errors (there was one bug in the
typing-only includes uncovered by this change) and is just one
more thing one has to think about when writing code.  Stop using
it and import the necessary types directly.  There may be a minor
slowdown during startup, but that's fine, it won't matter.