### PR TITLE
[DM-33604] Change the exposed URL to /api/cutout

### DIFF
--- a/src/vocutouts/handlers/external.py
+++ b/src/vocutouts/handlers/external.py
@@ -1,4 +1,4 @@
-"""Handlers for the app's external root, ``/utout``.
+"""Handlers for the app's external root, ``/api/cutout``.
 
 UWS provides general handlers for everything it can, but POST at the top level
 to create a new job has to be provided by the application since only the
@@ -65,7 +65,7 @@ _CAPABILITIES_TEMPLATE = """
     summary="Application metadata",
 )
 async def get_index() -> Index:
-    """GET ``/cutout/`` (the app's external root).
+    """GET ``/api/cutout/`` (the app's external root).
 
     Customize this handler to return whatever the top-level resource of your
     application should return. For example, consider listing key API URLs.

--- a/src/vocutouts/main.py
+++ b/src/vocutouts/main.py
@@ -37,9 +37,9 @@ app = FastAPI(
     title="vo-cutouts",
     description=metadata("vo-cutouts").get("Summary", ""),
     version=metadata("vo-cutouts").get("Version", "0.0.0"),
-    openapi_url=f"/{config.name}/openapi.json",
-    docs_url=f"/{config.name}/docs",
-    redoc_url=f"/{config.name}/redoc",
+    openapi_url=f"/api/{config.name}/openapi.json",
+    docs_url=f"/api/{config.name}/docs",
+    redoc_url=f"/api/{config.name}/redoc",
 )
 """The main FastAPI application for vo-cutouts."""
 
@@ -47,7 +47,7 @@ app = FastAPI(
 app.include_router(internal_router)
 app.include_router(
     external_router,
-    prefix=f"/{config.name}",
+    prefix=f"/api/{config.name}",
     responses={401: {"description": "Unauthenticated"}},
 )
 

--- a/tests/handlers/async_test.py
+++ b/tests/handlers/async_test.py
@@ -64,14 +64,14 @@ COMPLETED_JOB = """
 @pytest.mark.asyncio
 async def test_create_job(client: AsyncClient) -> None:
     r = await client.post(
-        "/cutout/jobs",
+        "/api/cutout/jobs",
         headers={"X-Auth-Request-User": "someone"},
         data={"ID": "1:2:band:value", "Pos": "CIRCLE 0 1 2"},
     )
     assert r.status_code == 303
-    assert r.headers["Location"] == "https://example.com/cutout/jobs/1"
+    assert r.headers["Location"] == "https://example.com/api/cutout/jobs/1"
     r = await client.get(
-        "/cutout/jobs/1", headers={"X-Auth-Request-User": "someone"}
+        "/api/cutout/jobs/1", headers={"X-Auth-Request-User": "someone"}
     )
     assert r.status_code == 200
     result = re.sub(r"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ", "[DATE]", r.text)
@@ -84,7 +84,7 @@ async def test_create_job(client: AsyncClient) -> None:
     # Try again but immediately queuing the job to run.
     try:
         r = await client.post(
-            "/cutout/jobs",
+            "/api/cutout/jobs",
             headers={"X-Auth-Request-User": "someone"},
             data={
                 "ID": "1:2:band:value",
@@ -94,16 +94,16 @@ async def test_create_job(client: AsyncClient) -> None:
             params={"phase": "RUN"},
         )
         assert r.status_code == 303
-        assert r.headers["Location"] == "https://example.com/cutout/jobs/2"
+        assert r.headers["Location"] == "https://example.com/api/cutout/jobs/2"
         r = await client.get(
-            "/cutout/jobs/2",
+            "/api/cutout/jobs/2",
             headers={"X-Auth-Request-User": "someone"},
             params={"wait": 2, "phase": "QUEUED"},
         )
         assert r.status_code == 200
         if "EXECUTING" in r.text:
             r = await client.get(
-                "/cutout/jobs/2",
+                "/api/cutout/jobs/2",
                 headers={"X-Auth-Request-User": "someone"},
                 params={"wait": 10, "phase": "EXECUTING"},
             )
@@ -133,7 +133,7 @@ async def test_bad_parameters(client: AsyncClient) -> None:
     ]
     for params in bad_params:
         r = await client.post(
-            "/cutout/jobs",
+            "/api/cutout/jobs",
             headers={"X-Auth-Request-User": "user"},
             data=params,
         )

--- a/tests/handlers/error_test.py
+++ b/tests/handlers/error_test.py
@@ -30,7 +30,7 @@ async def test_uncaught_error(client: AsyncClient) -> None:
     # Now try to start a job, which should throw a meaningful exception.
     with pytest.raises(ProgrammingError):
         await client.get(
-            "/cutout/sync",
+            "/api/cutout/sync",
             headers={"X-Auth-Request-User": "someone"},
             params={"ID": "1:2:band:id", "Pos": "CIRCLE 0 -2 2"},
         )

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -21,22 +21,24 @@ CAPABILITIES = """
     xmlns:vod="http://www.ivoa.net/xml/VODataService/v1.1">
   <capability standardID="ivo://ivoa.net/std/VOSI#capabilities">
     <interface xsi:type="vod:ParamHTTP" version="1.0">
-      <accessURL use="full">https://example.com/cutout/capabilities</accessURL>
+      <accessURL use="full">https://example.com/api/cutout/capabilities\
+</accessURL>
     </interface>
   </capability>
   <capability standardID="ivo://ivoa.net/std/VOSI#availability">
     <interface xsi:type="vod:ParamHTTP" version="1.0">
-      <accessURL use="full">https://example.com/cutout/availability</accessURL>
+      <accessURL use="full">https://example.com/api/cutout/availability\
+</accessURL>
     </interface>
   </capability>
   <capability standardid="ivo://ivoa.net/std/SODA#sync-1.0">
     <interface xsi:type="vod:ParamHTTP" role="std" version="1.0">
-      <accessURL use="full">https://example.com/cutout/sync</accessURL>
+      <accessURL use="full">https://example.com/api/cutout/sync</accessURL>
     </interface>
   </capability>
   <capability standardid="ivo://ivoa.net/std/SODA#async-1.0">
     <interface xsi:type="vod:ParamHTTP" role="std" version="1.0">
-      <accessURL use="full">https://example.com/cutout/jobs</accessURL>
+      <accessURL use="full">https://example.com/api/cutout/jobs</accessURL>
     </interface>
   </capability>
 </capabilities>
@@ -45,8 +47,8 @@ CAPABILITIES = """
 
 @pytest.mark.asyncio
 async def test_get_index(client: AsyncClient) -> None:
-    """Test ``GET /cutout/``"""
-    response = await client.get("/cutout/")
+    """Test ``GET /api/cutout/``"""
+    response = await client.get("/api/cutout/")
     assert response.status_code == 200
     data = response.json()
     metadata = data["metadata"]
@@ -59,13 +61,13 @@ async def test_get_index(client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_availability(client: AsyncClient) -> None:
-    r = await client.get("/cutout/availability")
+    r = await client.get("/api/cutout/availability")
     assert r.status_code == 200
     assert r.text == AVAILABILITY.strip()
 
 
 @pytest.mark.asyncio
 async def test_capabilities(client: AsyncClient) -> None:
-    r = await client.get("/cutout/capabilities")
+    r = await client.get("/api/cutout/capabilities")
     assert r.status_code == 200
     assert r.text == CAPABILITIES.strip()

--- a/tests/handlers/sync_test.py
+++ b/tests/handlers/sync_test.py
@@ -19,7 +19,7 @@ async def test_sync(client: AsyncClient) -> None:
     try:
         # GET request.
         r = await client.get(
-            "/cutout/sync",
+            "/api/cutout/sync",
             headers={"X-Auth-Request-User": "someone"},
             params={"ID": "1:2:band:id", "Pos": "CIRCLE 0 -2 2"},
         )
@@ -28,7 +28,7 @@ async def test_sync(client: AsyncClient) -> None:
 
         # POST request.
         r = await client.post(
-            "/cutout/sync",
+            "/api/cutout/sync",
             headers={"X-Auth-Request-User": "someone"},
             data={"ID": "3:4:band:id", "Pos": "CIRCLE 0 -2 2"},
         )
@@ -56,14 +56,14 @@ async def test_bad_parameters(client: AsyncClient) -> None:
     ]
     for params in bad_params:
         r = await client.get(
-            "/cutout/sync",
+            "/api/cutout/sync",
             headers={"X-Auth-Request-User": "user"},
             params=params,
         )
         assert r.status_code == 422, f"Parameters {params}"
         assert r.text.startswith("UsageError")
         r = await client.post(
-            "/cutout/sync",
+            "/api/cutout/sync",
             headers={"X-Auth-Request-User": "user"},
             data=params,
         )


### PR DESCRIPTION
In the current Science Platform URL scheme, the cutout service is
exposed as /api/cutout.  This previously was done with a rewrite
at the ingress layer to avoid encoding the /api path in the
application, since we anticipate moving the API Aspect to its own
domain name eventually.  However, this means that internal URLs
embedded in result documents are incorrect, particularly affecting
the /api/cutout/capabilities endpoint.

To simplify things, add /api as a prefix to the configured routes.
We can always remove it later if needed.