### PR TITLE
[DM-33719] Build a Docker image for the backend worker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,33 +85,27 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys:
-            ${{ runner.os }}-buildx-
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push the frontend image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
           tags: lsstsqre/vo-cutouts:${{ steps.vars.outputs.tag }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Build and push the worker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: ./Dockerfile.worker
+          tags: lsstsqre/vo-cutouts-worker:${{ steps.vars.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,8 +97,8 @@ jobs:
           context: .
           push: true
           tags: lsstsqre/vo-cutouts:${{ steps.vars.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
 
       - name: Build and push the worker image
         uses: docker/build-push-action@v2
@@ -107,5 +107,5 @@ jobs:
           push: true
           file: ./Dockerfile.worker
           tags: lsstsqre/vo-cutouts-worker:${{ steps.vars.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,30 @@
+# This Dockerfile constructs the image for cutout workers.  These images
+# are based on stack containers and install any required supporting code
+# for the image cutout backend, Dramatiq, and the backend worker definition.
+
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_2022_06
+
+# Reset the user to root since we need to do system install tasks.
+USER root
+
+# Upgrade the system packages.
+COPY scripts/install-worker-packages.sh .
+RUN ./install-worker-packages.sh && rm ./install-worker-packages.sh
+
+# Install the necessary prerequisites.
+COPY scripts/install-worker.sh .
+RUN ./install-worker.sh && rm ./install-worker.sh
+
+# Install the worker code.
+COPY src/vocutouts/workers.py /
+COPY scripts/start-worker.sh /
+
+# Create a non-root user
+RUN useradd --create-home appuser
+
+# Switch to the non-root user.
+USER appuser
+
+# Start the Dramatiq worker.
+WORKDIR /
+CMD ["/start-worker.sh"]

--- a/scripts/install-worker-packages.sh
+++ b/scripts/install-worker-packages.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Upgrade the CentOS packages in worker images.  This is done in a separate
+# script to create a separate cached Docker image, which will help with
+# iteration speed on the more interesting setup actions taken later in the
+# build.
+
+# Bash "strict mode", to help catch problems and bugs in the shell
+# script. Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+set -euo pipefail
+
+# Display each command as it's run.
+set -x
+
+# Upgrade the Red Hat packages.
+yum -y upgrade
+yum clean all

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This script updates and installs the necessary prerequisites for an image
+# cutout backend starting with a stack container.
+
+# Bash "strict mode", to help catch problems and bugs in the shell
+# script. Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+# set -u is omitted because the setup bash function does not support it.
+set -eo pipefail
+
+# Enable the stack.  This should be done before set -x because it will
+# otherwise spew a bunch of nonsense no one cares about into the logs.
+source /opt/lsst/software/stack/loadLSST.bash
+setup lsst_distrib
+
+# Display each command as it's run.
+set -x
+
+# Download the image cutout backend.  This can be removed if RFC-828 is
+# accepted, since that will include the image cutout backend in lsst-distrib.
+#
+# Currently, this uses the main branch because there appears to be no
+# alternative (no releases and no tags).
+mkdir /backend
+cd /backend
+git clone --depth 1 https://github.com/lsst-dm/image_cutout_backend.git
+cd image_cutout_backend
+setup -r .
+scons install declare -t current
+
+# Install Dramatiq.
+pip install --no-cache-dir 'dramatiq[redis]' structlog

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is installed in the worker image and starts the cutout backend
+# worker using Dramatiq.  It must run with the stack environment configured
+# and the image cutout backend imported.
+
+# Bash "strict mode", to help catch problems and bugs in the shell
+# script. Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+# set -u is omitted because the setup bash function does not support it.
+set -eo pipefail
+
+# Initialize the environment.
+source /opt/lsst/software/stack/loadLSST.bash
+setup lsst_distrib
+setup image_cutout_backend
+
+# Start Dramatiq with the worker.  Limit workers to one process (we will scale
+# horizontally in Kubernetes by adding more pods) and one thread (Butler is
+# not thread-safe when one instance is reused across multiple threads).
+dramatiq workers -Q cutout -p 1 -t 1

--- a/src/vocutouts/actors.py
+++ b/src/vocutouts/actors.py
@@ -52,7 +52,7 @@ __all__ = [
 ]
 
 
-@dramatiq.actor(queue_name="cutout", max_retries=1)
+@dramatiq.actor(queue_name="cutout", max_retries=1, store_results=True)
 def cutout(
     job_id: str,
     dataset_ids: List[str],

--- a/src/vocutouts/workers.py
+++ b/src/vocutouts/workers.py
@@ -83,7 +83,7 @@ class TaskTransientError(Exception):
     """Some transient problem occurred."""
 
 
-@dramatiq.actor(queue_name="cutout", max_retries=1)
+@dramatiq.actor(queue_name="cutout", max_retries=1, store_results=True)
 def cutout(
     job_id: str,
     dataset_ids: List[str],


### PR DESCRIPTION
Build a custom Docker image for the backend worker on top of the
stack Docker image.  Update the Docker image build rules to use
the new GitHub Actions cache mechanism.

Add `store_results` to the actor configuration. For some reason this
doesn't seem necessary for everything to work, but in theory it
should be required to pass results to the callback, and without this
setting Dramatiq issues a warning for every job.