### PR TITLE
[DM-34998] Data IDs are now Butler URIs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Change log
 ##########
 
-0.4.0 (unreleased)
+0.4.0 (2022-05-31)
 ==================
 
 - Dataset IDs are now Butler URIs instead of just the bare UUID.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,12 @@
 Change log
 ##########
 
-0.3.1 (unreleased)
+0.4.0 (unreleased)
 ==================
 
+- Data IDs are now Butler URIs instead of just the bare UUID.
+  The ``CUTOUT_BUTLER_REPOSITORY`` configuration setting is no longer used.
+  Instead, the backend maintains one instance of a Butler and corresponding cutout backend per named Butler repository, taken from the first component of the Butler URI.
 - Drop support for Python 3.8.
 - Update dependencies.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Change log
 0.4.0 (unreleased)
 ==================
 
-- Data IDs are now Butler URIs instead of just the bare UUID.
+- Dataset IDs are now Butler URIs instead of just the bare UUID.
   The ``CUTOUT_BUTLER_REPOSITORY`` configuration setting is no longer used.
   Instead, the backend maintains one instance of a Butler and corresponding cutout backend per named Butler repository, taken from the first component of the Butler URI.
 - Drop support for Python 3.8.
@@ -34,7 +34,7 @@ The database schema of this version is incompatible with 0.1.0.
 The database must be wiped and recreated during the upgrade.
 
 - Use ``lsst.image_cutout_backend`` as the backend instead of ``pipetask`` without conversion of coordinates to pixels.
-- Data IDs are now Butler UUIDs instead of colon-separated tuples.
+- Dataset IDs are now Butler UUIDs instead of colon-separated tuples.
 - Support POLYGON and CIRCLE stencils and stop supporting POS RANGE, matching the capabilities of the new backend.
 - Use a separate S3 bucket to store the output rather than a Butler collection.
   Eliminate use of Butler in the frontend, in favor of using that S3 bucket directly.

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, Dramatiq, and the backend worker definition.
 
-FROM lsstsqre/centos:7-stack-lsst_distrib-w_2022_06
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_2022_12
 
 # Reset the user to root since we need to do system install tasks.
 USER root

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -29,5 +29,5 @@ cd image_cutout_backend
 setup -r .
 scons install declare -t current
 
-# Install Dramatiq.
-pip install --no-cache-dir 'dramatiq[redis]' structlog
+# Install Python dependencies.
+pip install --no-cache-dir 'dramatiq[redis]' safir structlog

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -18,7 +18,8 @@ setup lsst_distrib
 set -x
 
 # Download the image cutout backend.  This can be removed if RFC-828 is
-# accepted, since that will include the image cutout backend in lsst-distrib.
+# implemented, since that will include the image cutout backend in
+# lsst-distrib.
 #
 # Currently, this uses the main branch because there appears to be no
 # alternative (no releases and no tags).

--- a/src/vocutouts/config.py
+++ b/src/vocutouts/config.py
@@ -15,13 +15,6 @@ __all__ = ["Configuration", "config"]
 class Configuration:
     """Configuration for vocutouts."""
 
-    butler_repository: str = os.getenv("CUTOUT_BUTLER_REPOSITORY", "")
-    """The Butler repository holding source images for cutouts.
-
-    Set with the ``CUTOUT_BUTLER_REPOSITORY`` environment variable.  Setting
-    this is mandatory.
-    """
-
     storage_url: str = os.getenv("CUTOUT_STORAGE_URL", "")
     """The root URL to use to store cutout results.
 

--- a/src/vocutouts/main.py
+++ b/src/vocutouts/main.py
@@ -51,13 +51,17 @@ app.include_router(
     responses={401: {"description": "Unauthenticated"}},
 )
 
+# Install middleware.
+app.add_middleware(XForwardedMiddleware)
+app.add_middleware(CaseInsensitiveQueryMiddleware)
+
+# Install error handlers.
+install_error_handlers(app)
+
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    app.add_middleware(XForwardedMiddleware)
-    app.add_middleware(CaseInsensitiveQueryMiddleware)
     logger = structlog.get_logger(config.logger_name)
-    install_error_handlers(app)
     await uws_dependency.initialize(
         config=config.uws_config(),
         policy=ImageCutoutPolicy(cutout, logger),

--- a/src/vocutouts/models/parameters.py
+++ b/src/vocutouts/models/parameters.py
@@ -15,7 +15,7 @@ class CutoutParameters:
     """The parameters to a cutout request."""
 
     ids: List[str]
-    """The data IDs on which to operate."""
+    """The dataset IDs on which to operate."""
 
     stencils: List[Stencil]
     """The cutout stencils to apply."""
@@ -54,7 +54,7 @@ class CutoutParameters:
             msg = f"Invalid cutout parameter: {type(e).__name__}: {str(e)}"
             raise InvalidCutoutParameterError(msg, params) from e
         if not ids:
-            raise InvalidCutoutParameterError("No data ID given", params)
+            raise InvalidCutoutParameterError("No dataset ID given", params)
         if not stencils:
             raise InvalidCutoutParameterError(
                 "No cutout stencil given", params

--- a/src/vocutouts/policy.py
+++ b/src/vocutouts/policy.py
@@ -55,8 +55,8 @@ class ImageCutoutPolicy(UWSPolicy):
 
         Notes
         -----
-        Currently, only one data ID and only one stencil are supported.  This
-        limitation is expected to be relaxed in a later version.
+        Currently, only one dataset ID and only one stencil are supported.
+        This limitation is expected to be relaxed in a later version.
         """
         cutout_params = CutoutParameters.from_job_parameters(job.parameters)
         return self._actor.send_with_options(

--- a/src/vocutouts/workers.py
+++ b/src/vocutouts/workers.py
@@ -175,9 +175,9 @@ def cutout(
     now = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     job_started.send(job_id, message.message_id, now)
 
-    # Currently, only a single data ID and a single stencil are supported.
+    # Currently, only a single dataset ID and a single stencil are supported.
     if len(dataset_ids) != 1:
-        msg = "Only one data ID supported"
+        msg = "Only one dataset ID supported"
         logger.warning(msg)
         raise TaskFatalError(f"UsageError {msg}")
     if len(stencils) != 1:

--- a/src/vocutouts/workers.py
+++ b/src/vocutouts/workers.py
@@ -44,6 +44,7 @@ configure_logging(
     name=os.getenv("SAFIR_LOGGER", "vocutouts"),
     profile=os.getenv("SAFIR_PROFILE", "production"),
     log_level=os.getenv("SAFIR_LOG_LEVEL", "INFO"),
+    add_timestamp=True,
 )
 redis_host = os.environ["CUTOUT_REDIS_HOST"]
 redis_password = os.getenv("CUTOUT_REDIS_PASSWORD")


### PR DESCRIPTION
Expect a Butler URI as the data ID instead of a bare UUID.  The
CUTOUT_BUTLER_REPOSITORY configuration setting is no longer used.
Instead, the backend worker maintains one instance of a Butler and
corresponding cutout backend per named Butler repository,
determined by parsing the data ID and taking the "host" component
as the name of the Butler repository and the "path" (without the
leading slash) as the UUID.

Also adds some additional backend logging and updates the stack
image used by the cutout worker.