### PR TITLE
[DM-35058] Disable masking on cutouts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+0.4.1 (unreleased)
+==================
+
+- Stop masking pixels outside the cutout stencil.
+  The current performance of masking is unreasonably slow for ``CIRCLE`` cutouts, and masking isn't required by the SODA standard.
+  We may revisit this later with a faster algorithm.
+
 0.4.0 (2022-05-31)
 ==================
 

--- a/src/vocutouts/workers.py
+++ b/src/vocutouts/workers.py
@@ -219,7 +219,6 @@ def cutout(
         logger.exception("Cutout processing failed")
         msg = f"Error Cutout processing failed\n{type(e).__name__}: {str(e)}"
         raise TaskTransientError(msg)
-    logger.info("Cutout request completed")
 
     # Return the result URL.  This must be a dict representation of a
     # vocutouts.uws.models.JobResult.

--- a/src/vocutouts/workers.py
+++ b/src/vocutouts/workers.py
@@ -214,7 +214,7 @@ def cutout(
     # Perform the cutout.
     logger.info("Starting cutout request")
     try:
-        result = backend.process_uuid(sky_stencils[0], uuid)
+        result = backend.process_uuid(sky_stencils[0], uuid, mask_plane=None)
     except Exception as e:
         logger.exception("Cutout processing failed")
         msg = f"Error Cutout processing failed\n{type(e).__name__}: {str(e)}"


### PR DESCRIPTION
The masking, particularly circular masking for a circle cutout,
is very compute-intensive and takes much too long, even if tuned
down to an octagon.  Disable masking for DP0.2.  We can revisit
later with a more performant algorithm.