### PR TITLE
[DM-35516] Enable clipping of the cutout stencil

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
           - "3.10"
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change log
 ##########
 
+0.4.2 (2022-07-14)
+==================
+
+- Clip stencils at the edge of the image instead of raising an error in the backend.
+  Practical experience with the Portal and deeper thought about possible scientific use cases have shown this to be a more practical and user-friendly approach.
+- Drop support for Python 3.9.
+- Update dependencies.
+
 0.4.1 (2022-06-01)
 ==================
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, Dramatiq, and the backend worker definition.
 
-FROM lsstsqre/centos:7-stack-lsst_distrib-w_2022_12
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_2022_22
 
 # Reset the user to root since we need to do system install tasks.
 USER root

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Natural Language :: English
     Operating System :: POSIX
@@ -29,7 +28,7 @@ include_package_data = True
 package_dir =
     = src
 packages=find:
-python_requires = >=3.9
+python_requires = >=3.10
 setup_requires =
     setuptools_scm
 # Use requirements/main.in for runtime dependencies instead of install_requires

--- a/src/vocutouts/workers.py
+++ b/src/vocutouts/workers.py
@@ -199,12 +199,12 @@ def cutout(
                 frame="icrs",
             )
             radius = Angle(stencil_dict["radius"] * u.degree)
-            stencil = SkyCircle.from_astropy(center, radius)
+            stencil = SkyCircle.from_astropy(center, radius, clip=True)
         elif stencil_dict["type"] == "polygon":
             ras = [v[0] for v in stencil_dict["vertices"]]
             decs = [v[1] for v in stencil_dict["vertices"]]
             vertices = SkyCoord(ras * u.degree, decs * u.degree, frame="icrs")
-            stencil = SkyPolygon.from_astropy(vertices)
+            stencil = SkyPolygon.from_astropy(vertices, clip=True)
         else:
             msg = f'Unknown stencil type {stencil_dict["type"]}'
             logger.warning(msg)


### PR DESCRIPTION
We originally wanted to raise an error if the cutout stencil didn't
fall within the bounds of the image, but some practical experience
with the Portal has shown that it's better if the stencil clips at
the edge of the image.  This also makes it easier to, for example,
take circular cutouts around a specific object in lots of separate
images that may have different geometries.