### PR TITLE
DM-37516: Bump stack container version

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, Dramatiq, and the backend worker definition.
 
-FROM lsstsqre/centos:7-stack-lsst_distrib-w_2022_22
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_2022_40
 
 # Reset the user to root since we need to do system install tasks.
 USER root


### PR DESCRIPTION
Update the stack container to w_2022_40 (the latest recommended).