### PR TITLE
DM-37516: Stop pushing containers to Docker Hub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      # We no longer push to Docker Hub, but continue to log in so that our
+      # pulls of the stack container are authenticated and thus less likely to
+      # get rate-limited.
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -100,7 +103,6 @@ jobs:
           context: .
           push: true
           tags: |
-            lsstsqre/vo-cutouts:${{ steps.vars.outputs.tag }}
             ghcr.io/lsst-sqre/vo-cutouts:${{ steps.vars.outputs.tag }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
@@ -112,7 +114,6 @@ jobs:
           push: true
           file: ./Dockerfile.worker
           tags: |
-            lsstsqre/vo-cutouts-worker:${{ steps.vars.outputs.tag }}
             ghcr.io/lsst-sqre/vo-cutouts-worker:${{ steps.vars.outputs.tag }}
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker


### PR DESCRIPTION
Keep the login so that our pulls of the huge stack container are authenticated, but stop uploading containers to Docker Hub.  We only use GitHub Artifact Repository these days.