### PR TITLE
Fix package version

### DIFF
--- a/src/vocutouts/__init__.py
+++ b/src/vocutouts/__init__.py
@@ -8,7 +8,7 @@ __version__: str
 """The application version string (PEP 440 / SemVer compatible)."""
 
 try:
-    __version__ = version(__name__)
+    __version__ = version("vo-cutouts")
 except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"


### PR DESCRIPTION
The version was being set from the wrong name.  Use the proper distribution name instead of the Python package name.