### PR TITLE
DM-42937: Update run target and mypy configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ init:
 	rm -rf .tox
 	pre-commit install
 
+.PHONY: run
+run:
+	tox run -e run
+
 .PHONY: update
 update: update-deps init
 
@@ -39,7 +43,3 @@ update-deps-no-hashes:
 	    --output-file requirements/main.txt requirements/main.in
 	uv pip compile --upgrade					\
 	    --output-file requirements/dev.txt requirements/dev.in
-
-.PHONY: run
-run:
-	tox -e run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,25 +84,39 @@ line_length = 79
 known_first_party = ["vocutouts", "tests"]
 skip = ["docs/conf.py"]
 
-[tool.pytest.ini_options]
-asyncio_mode = "strict"
-python_files = [
-    "tests/*.py",
-    "tests/*/*.py"
-]
-
 [tool.mypy]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 ignore_missing_imports = true
 local_partial_types = true
+plugins = [
+    "pydantic.mypy",
+    "sqlalchemy.ext.mypy.plugin",
+]
 no_implicit_reexport = true
 show_error_codes = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
-plugins = "sqlalchemy.ext.mypy.plugin"
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+# The python_files setting is not for test detection (pytest will pick up any
+# test files named *_test.py without this setting) but to enable special
+# assert processing in any non-test supporting files under tests.  We
+# conventionally put test support functions under tests.support and may
+# sometimes use assert in test fixtures in conftest.py, and pytest only
+# enables magical assert processing (showing a full diff on assert failures
+# with complex data structures rather than only the assert message) in files
+# listed in python_files.
+python_files = ["tests/*.py", "tests/*/*.py"]
 
 [tool.scriv]
 categories = [


### PR DESCRIPTION
Fix the `make run` target for the current tox syntax. Update the mypy configuration and enable the Pydantic mypy plugin.