### PR TITLE
DM-42937: Switch to pydantic-settings for configuration

### DIFF
--- a/changelog.d/20240216_171711_rra_DM_42937.md
+++ b/changelog.d/20240216_171711_rra_DM_42937.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Standardize the environment variables used for configuration. Rename `SAFIR_` environment variables to `CUTOUT_`, remove `SAFIR_LOG_NAME`, and add `CUTOUT_PATH_PREFIX` to control the API path prefix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,9 +164,6 @@ ignore = [
     "COM819",
     "ISC001",
     "ISC002",
-
-    # TEMPORARY
-    "RUF009",
 ]
 select = ["ALL"]
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -222,9 +222,9 @@ pluggy==1.4.0 \
 pre-commit==3.6.1 \
     --hash=sha256:9fe989afcf095d2c4796ce7c553cf28d4d4a9b9346de3cda079bcf40748454a4 \
     --hash=sha256:c90961d8aa706f75d60935aba09469a6b0bcb8345f127c3fbee4bdc5f114cf4b
-pytest==8.0.0 \
-    --hash=sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c \
-    --hash=sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6
+pytest==8.0.1 \
+    --hash=sha256:267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae \
+    --hash=sha256:3e4f16fe1c0a9dc9d9389161c127c3edc5d810c38d6793042fb81d9f48a59fca
     # via
     #   pytest-asyncio
     #   pytest-cov

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -6,7 +6,7 @@
 #     make update-deps
 
 # These dependencies are for fastapi including some optional features.
-fastapi!=0.89.0
+fastapi
 python-multipart
 starlette
 uvicorn[standard]
@@ -20,6 +20,8 @@ google-auth
 google-cloud-storage
 jinja2
 psycopg2
+pydantic
+pydantic-settings
 safir[db,gcs]
 sqlalchemy[asyncio]
 structlog

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -671,6 +671,7 @@ pydantic==2.6.1 \
     --hash=sha256:4fd5c182a2488dc63e6d32737ff19937888001e2a6d86e94b3f233104a5d1fa9
     # via
     #   fastapi
+    #   pydantic-settings
     #   safir
 pydantic-core==2.16.2 \
     --hash=sha256:02906e7306cb8c5901a1feb61f9ab5e5c690dbbeaa04d84c1b9ae2a01ebe9379 \
@@ -753,6 +754,9 @@ pydantic-core==2.16.2 \
     --hash=sha256:fe56851c3f1d6f5384b3051c536cc81b3a93a73faf931f404fef95217cf1e10d \
     --hash=sha256:ff7c97eb7a29aba230389a2661edf2e9e06ce616c7e35aa764879b6894a44b25
     # via pydantic
+pydantic-settings==2.2.0 \
+    --hash=sha256:5f7bcaf9ad4419559dc5ac155c0324a9aeb2547c60471ee7c7d026f467a6b515 \
+    --hash=sha256:648d0a76673e69c51278979cba2e83cf16a23d57519bfd7e553d1c3f37db5560
 pyerfa==2.0.1.1 \
     --hash=sha256:08b5abb90b34e819c1fca69047a76c0d344cb0c8fe4f7c8773f032d8afd623b4 \
     --hash=sha256:0e95cf3d11f76f473bf011980e9ea367ca7e68ca675d8b32499814fb6e387d4c \
@@ -773,7 +777,9 @@ pyjwt==2.8.0 \
 python-dotenv==1.0.1 \
     --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
     --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
-    # via uvicorn
+    # via
+    #   pydantic-settings
+    #   uvicorn
 python-multipart==0.0.9 \
     --hash=sha256:03f54688c663f1b7977105f021043b0793151e4cb1c1a9d4a11fc13d622c4026 \
     --hash=sha256:97ca7b8ea7b05f977dc3849c3ba99d51689822fab725c3703af7c866a0c2b215

--- a/src/vocutouts/actors.py
+++ b/src/vocutouts/actors.py
@@ -40,7 +40,6 @@ import dramatiq
 import structlog
 
 from . import broker
-from .config import config
 from .uws.jobs import uws_job_completed, uws_job_failed, uws_job_started
 from .uws.utils import parse_isodatetime
 
@@ -111,7 +110,7 @@ def job_started(job_id: str, message_id: str, start_time: str) -> None:
     test suite, where a job will be marked as completed but won't have a start
     time (and hopefully will fix the same issue in a production deployment).
     """
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("vocutouts")
     start = parse_isodatetime(start_time)
     if not broker.worker_session:
         raise RuntimeError("Worker database connection not initalized")
@@ -125,7 +124,7 @@ def job_completed(
     message: dict[str, Any], result: list[dict[str, str]]
 ) -> None:
     """Call the UWS function to mark a job as completed."""
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("vocutouts")
     job_id = message["args"][0]
     if not broker.worker_session:
         raise RuntimeError("Worker database connection not initalized")
@@ -135,7 +134,7 @@ def job_completed(
 @dramatiq.actor(queue_name="uws", priority=20)
 def job_failed(message: dict[str, Any], exception: dict[str, str]) -> None:
     """Call the UWS function to mark a job as errored."""
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("vocutouts")
     job_id = message["args"][0]
     if not broker.worker_session:
         raise RuntimeError("Worker database connection not initalized")

--- a/src/vocutouts/broker.py
+++ b/src/vocutouts/broker.py
@@ -47,9 +47,9 @@ class WorkerSession(Middleware):
         """
         global worker_session
         if worker_session is None:
-            logger = structlog.get_logger(config.logger_name)
+            logger = structlog.get_logger("vocutouts")
             worker_session = create_sync_session(
-                config.database_url,
+                str(config.database_url),
                 config.database_password,
                 logger,
                 isolation_level="REPEATABLE READ",

--- a/src/vocutouts/cli.py
+++ b/src/vocutouts/cli.py
@@ -45,9 +45,9 @@ def run(port: int) -> None:
 @run_with_asyncio
 async def init(*, reset: bool) -> None:
     """Initialize the database storage."""
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("vocutouts")
     engine = create_database_engine(
-        config.database_url,
+        str(config.database_url),
         config.database_password,
     )
     await initialize_database(

--- a/src/vocutouts/handlers/external.py
+++ b/src/vocutouts/handlers/external.py
@@ -142,7 +142,10 @@ async def _sync_request(
     await job_service.start(user, job.job_id, access_token)
     logger.info("Started job", job_id=job.job_id)
     job = await job_service.get(
-        user, job.job_id, wait=config.sync_timeout, wait_for_completion=True
+        user,
+        job.job_id,
+        wait_seconds=int(config.sync_timeout.total_seconds()),
+        wait_for_completion=True,
     )
 
     # Check for error states.

--- a/src/vocutouts/main.py
+++ b/src/vocutouts/main.py
@@ -28,18 +28,16 @@ __all__ = ["app", "config"]
 
 
 configure_logging(
-    profile=config.profile,
-    log_level=config.log_level,
-    name=config.logger_name,
+    name="vocutouts", profile=config.profile, log_level=config.log_level
 )
 
 app = FastAPI(
     title="vo-cutouts",
     description=metadata("vo-cutouts")["Summary"],
     version=version("vo-cutouts"),
-    openapi_url=f"/api/{config.name}/openapi.json",
-    docs_url=f"/api/{config.name}/docs",
-    redoc_url=f"/api/{config.name}/redoc",
+    openapi_url=f"{config.path_prefix}/openapi.json",
+    docs_url=f"{config.path_prefix}/docs",
+    redoc_url=f"{config.path_prefix}/redoc",
 )
 """The main FastAPI application for vo-cutouts."""
 
@@ -47,7 +45,7 @@ app = FastAPI(
 app.include_router(internal_router)
 app.include_router(
     external_router,
-    prefix=f"/api/{config.name}",
+    prefix=config.path_prefix,
     responses={401: {"description": "Unauthenticated"}},
 )
 
@@ -61,7 +59,7 @@ install_error_handlers(app)
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("vocutouts")
     await uws_dependency.initialize(
         config=config.uws_config(),
         policy=ImageCutoutPolicy(cutout, logger),

--- a/src/vocutouts/uws/config.py
+++ b/src/vocutouts/uws/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import timedelta
 
 __all__ = ["UWSConfig"]
 
@@ -19,14 +20,14 @@ class UWSConfig:
     `vocutouts.uws.dependencies.UWSDependency` object.
     """
 
-    execution_duration: int
+    execution_duration: timedelta
     """Maximum execution time in seconds.
 
     Jobs that run longer than this length of time will be automatically
     aborted.
     """
 
-    lifetime: int
+    lifetime: timedelta
     """The lifetime of jobs in seconds.
 
     After this much time elapses since the creation of the job, all of the
@@ -54,8 +55,8 @@ class UWSConfig:
     redis_password: str | None = None
     """Password for the Redis server used by Dramatiq."""
 
-    url_lifetime: int = 15 * 60
-    """How long result URLs should be valid for in minutes."""
+    url_lifetime: timedelta = timedelta(minutes=15)
+    """How long result URLs should be valid for."""
 
-    wait_timeout: int = 60
-    """Maximum time in seconds a client can wait for a job change."""
+    wait_timeout: timedelta = timedelta(minutes=1)
+    """Maximum time a client can wait for a job change."""

--- a/src/vocutouts/uws/handlers.py
+++ b/src/vocutouts/uws/handlers.py
@@ -123,7 +123,9 @@ async def get_job(
     uws_factory: Annotated[UWSFactory, Depends(uws_dependency)],
 ) -> Response:
     job_service = uws_factory.create_job_service()
-    job = await job_service.get(user, job_id, wait=wait, wait_phase=phase)
+    job = await job_service.get(
+        user, job_id, wait_seconds=wait, wait_phase=phase
+    )
     templates = uws_factory.create_templates()
     return await templates.job(request, job)
 

--- a/src/vocutouts/uws/models.py
+++ b/src/vocutouts/uws/models.py
@@ -56,11 +56,11 @@ class ExecutionPhase(Enum):
     """Execution completed some time ago and the results have been deleted."""
 
 
-ACTIVE_PHASES = (
+ACTIVE_PHASES = {
     ExecutionPhase.PENDING,
     ExecutionPhase.QUEUED,
     ExecutionPhase.EXECUTING,
-)
+}
 """Phases in which the job is active and can be waited on."""
 
 

--- a/src/vocutouts/uws/results.py
+++ b/src/vocutouts/uws/results.py
@@ -7,8 +7,6 @@ URL to a signed URL suitable for returning to a client of the service.
 
 from __future__ import annotations
 
-from datetime import timedelta
-
 from safir.gcs import SignedURLService
 
 from .config import UWSConfig
@@ -30,7 +28,7 @@ class ResultStore:
         self._config = config
         self._url_service = SignedURLService(
             service_account=config.signing_service_account,
-            lifetime=timedelta(seconds=config.url_lifetime),
+            lifetime=config.url_lifetime,
         )
 
     async def url_for_result(self, result: JobResult) -> JobResultURL:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,11 +57,11 @@ async def app() -> AsyncIterator[FastAPI]:
     creating the app to ensure that data is dropped from a persistent database
     between test cases.
     """
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("vocutouts")
     broker.flush_all()
     broker.emit_after("process_boot")
     engine = create_database_engine(
-        config.database_url, config.database_password
+        str(config.database_url), config.database_password
     )
     await initialize_database(engine, logger, schema=Base.metadata, reset=True)
     await engine.dispose()
@@ -76,7 +76,6 @@ async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
     async with AsyncClient(
         app=app,
         base_url="https://example.com/",
-        # Mock the Gafaelfawr delegated token header.
         headers={"X-Auth-Request-Token": "sometoken"},
     ) as client:
         yield client

--- a/tests/handlers/error_test.py
+++ b/tests/handlers/error_test.py
@@ -23,7 +23,7 @@ async def test_uncaught_error(client: AsyncClient) -> None:
     # no meaningful information and no exception traceback due a bug in
     # swallowing errors in subapps.
     engine = create_database_engine(
-        config.database_url, config.database_password
+        str(config.database_url), config.database_password
     )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,8 @@ setenv =
     CUTOUT_DATABASE_URL = postgresql://vo-cutouts@127.0.0.1/vo-cutouts
     CUTOUT_DATABASE_PASSWORD = INSECURE-PASSWORD
     CUTOUT_REDIS_HOST = 127.0.0.1
+    CUTOUT_SERVICE_ACCOUNT = "vo-cutouts@example.com"
+    CUTOUT_STORAGE_URL = "s3://some-bucket"
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).
@@ -65,25 +67,6 @@ skip_install = true
 deps =
     pre-commit
 commands = pre-commit run --all-files
-
-[testenv:run]
-description = Run the development server with auto-reload for code changes.
-usedevelop = true
-whitelist_externals =
-    docker-compose
-commands_pre =
-    docker-compose up -d
-    holdup -t 60 -T 5 -i 1 -n tcp://localhost:6379/
-    holdup -t 60 -T 5 -i 1 -n tcp://localhost:5432/
-commands =
-    vo-cutouts init
-    vo-cutouts run
-commands_post =
-    docker-compose down
-setenv =
-    CUTOUT_DATABASE_URL = postgresql://vo-cutouts@127.0.0.1/vo-cutouts
-    CUTOUT_DATABASE_PASSWORD = INSECURE-PASSWORD
-    CUTOUT_REDIS_HOST = 127.0.0.1
 
 [testenv:typing]
 description = Run mypy.


### PR DESCRIPTION
Use pydantic-settings to gather the configuration, and use a standard prefix of CUTOUT_ for all environment variables. Drop the SAFIR_LOG_NAME setting and add CONFIG_PATH_PREFIX to control the API path prefix.

Make the configuration setting names match the environment variables and use timedelta for more time deltas rather than integer numbers of seconds. Start using some of the Safir datetime support functions.