### PR TITLE
DM-42937: Remove deprecated FastAPI and Starlette constructs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ warn_untyped_fields = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+filterwarnings = [
+    # Google modules use PyType_Spec in a deprecated way.
+    "ignore:Type google\\..*metaclass.* custom tp_new:DeprecationWarning",
+]
 # The python_files setting is not for test detection (pytest will pick up any
 # test files named *_test.py without this setting) but to enable special
 # assert processing in any non-test supporting files under tests.  We

--- a/src/vocutouts/uws/handlers.py
+++ b/src/vocutouts/uws/handlers.py
@@ -225,7 +225,7 @@ async def post_job_destruction(
         Form(
             title="New destruction time",
             description="Must be in ISO 8601 format.",
-            example="2021-09-10T10:01:02Z",
+            examples=["2021-09-10T10:01:02Z"],
         ),
     ] = None,
     params: Annotated[list[JobParameter], Depends(uws_post_params_dependency)],
@@ -315,7 +315,7 @@ async def post_job_execution_duration(
         Form(
             title="New execution duration",
             description="Integer seconds of wall clock time.",
-            example=14400,
+            examples=[14400],
         ),
     ] = None,
     params: Annotated[list[JobParameter], Depends(uws_post_params_dependency)],

--- a/src/vocutouts/uws/responses.py
+++ b/src/vocutouts/uws/responses.py
@@ -34,16 +34,18 @@ class UWSTemplates:
     ) -> Response:
         """Return the availability of a service as an XML response."""
         return _templates.TemplateResponse(
+            request,
             "availability.xml",
-            {"availability": availability, "request": request},
+            {"availability": availability},
             media_type="application/xml",
         )
 
     def error(self, request: Request, error: JobError) -> Response:
         """Return the error of a job as an XML response."""
         return _templates.TemplateResponse(
+            request,
             "error.xml",
-            {"error": error, "request": request},
+            {"error": error},
             media_type="application/xml",
         )
 
@@ -53,8 +55,9 @@ class UWSTemplates:
             await self._result_store.url_for_result(r) for r in job.results
         ]
         return _templates.TemplateResponse(
+            request,
             "job.xml",
-            {"job": job, "results": results, "request": request},
+            {"job": job, "results": results},
             media_type="application/xml",
         )
 
@@ -63,16 +66,18 @@ class UWSTemplates:
     ) -> Response:
         """Return a list of jobs as an XML response."""
         return _templates.TemplateResponse(
+            request,
             "jobs.xml",
-            {"base_url": base_url, "jobs": jobs, "request": request},
+            {"base_url": base_url, "jobs": jobs},
             media_type="application/xml",
         )
 
     def parameters(self, request: Request, job: Job) -> Response:
         """Return the parameters for a job as an XML response."""
         return _templates.TemplateResponse(
+            request,
             "parameters.xml",
-            {"job": job, "request": request},
+            {"job": job},
             media_type="application/xml",
         )
 
@@ -82,7 +87,8 @@ class UWSTemplates:
             await self._result_store.url_for_result(r) for r in job.results
         ]
         return _templates.TemplateResponse(
+            request,
             "results.xml",
-            {"results": results, "request": request},
+            {"results": results},
             media_type="application/xml",
         )


### PR DESCRIPTION
Switch to the lifespan context manager, switch to the new TemplateResponse syntax, and switch a few instances of example to examples. Exclude some warnings from the Google libraries.