### PR TITLE
DM-42937: Simplify the Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,10 @@
 # base-image
 #   Updates the base Python image with security patches and common system
 #   packages. This image becomes the base of all other images.
-# dependencies-image
-#   Installs third-party dependencies (requirements/main.txt) into a virtual
-#   environment. This virtual environment is ideal for copying across build
-#   stages.
 # install-image
-#   Installs the app into the virtual environment.
+#   Installs third-party dependencies (requirements/main.txt) and the
+#   application into a virtual environment. This virtual environment is
+#   ideal for copying across build stages.
 # runtime-image
 #   - Copies the virtual environment into place.
 #   - Runs a non-root user.
@@ -20,7 +18,7 @@ FROM python:3.12.2-slim-bullseye as base-image
 COPY scripts/install-base-packages.sh .
 RUN ./install-base-packages.sh && rm ./install-base-packages.sh
 
-FROM base-image AS dependencies-image
+FROM base-image AS install-image
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .
@@ -29,8 +27,10 @@ RUN ./install-dependency-packages.sh
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV
+
 # Make sure we use the virtualenv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 # Put the latest pip and setuptools in the virtualenv
 RUN pip install --upgrade --no-cache-dir pip setuptools wheel
 
@@ -38,11 +38,7 @@ RUN pip install --upgrade --no-cache-dir pip setuptools wheel
 COPY requirements/main.txt ./requirements.txt
 RUN pip install --quiet --no-cache-dir -r requirements.txt
 
-FROM dependencies-image AS install-image
-
-# Use the virtualenv
-ENV PATH="/opt/venv/bin:$PATH"
-
+# Install the application.
 COPY . /workdir
 WORKDIR /workdir
 RUN pip install --no-cache-dir .

--- a/changelog.d/20240219_145935_rra_DM_42937.md
+++ b/changelog.d/20240219_145935_rra_DM_42937.md
@@ -1,0 +1,3 @@
+### New features
+
+- Send uvicorn logs through structlog for consistent JSON formatting and add context expected by Google Cloud Logging to each log message.

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -9,26 +9,24 @@
 
 # Bash "strict mode", to help catch problems and bugs in the shell
 # script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
 set -x
 
-# Tell apt-get we're never going to be able to give manual
-# feedback:
+# Tell apt-get we're never going to be able to give manual feedback.
 export DEBIAN_FRONTEND=noninteractive
 
-# Update the package listing, so we know what packages exist:
+# Update the package listing, so we know what packages exist.
 apt-get update
 
-# Install security updates:
+# Install security updates.
 apt-get -y upgrade
 
-# git is required by setuptools-scm.  libpq-dev is required by psycopg2.
-apt-get -y install --no-install-recommends git libpq-dev
+# Install dependencies required at runtime. libpq-dev is required by psycopg2.
+apt-get -y install --no-install-recommends libpq-dev
 
-# Delete cached files we don't need anymore:
+# Delete cached files we don't need anymore.
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -10,24 +10,24 @@
 
 # Bash "strict mode", to help catch problems and bugs in the shell
 # script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
 set -x
 
-# Tell apt-get we're never going to be able to give manual
-# feedback:
+# Tell apt-get we're never going to be able to give manual feedback.
 export DEBIAN_FRONTEND=noninteractive
 
-# Update the package listing, so we know what packages exist:
+# Update the package listing, so we know what packages exist.
 apt-get update
 
-# Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.  libffi-dev
-# is sometimes needed to build cffi (a cryptography dependency).
-apt-get -y install --no-install-recommends build-essential libffi-dev
+# Install various dependencies that may be required to install vo-cutouts:
+#
+# build-essential: sometimes needed to build Python modules
+# git: required by setuptools_scm
+# libffi-dev: sometimes needed to build cffi, a cryptography dependency
+apt-get -y install --no-install-recommends build-essential git libffi-dev
 
 # Delete cached files we don't need anymore:
 apt-get clean


### PR DESCRIPTION
Use a three-stage build instead of a four-stage build by combining the dependencies image and the install image, since we do not take advantage of their separation for caching. Move git to the install image from the base image, since setuptools_scm only requires it during install.