### PR TITLE
DM-44606: Drop pydantic-settings from worker, add timeout

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -33,6 +33,6 @@ scons install declare -t current
 
 # Install Python dependencies and the vo-cutouts code.
 cd "$1"
-pip install --no-cache-dir pydantic-settings google-auth google-cloud-storage
+pip install --no-cache-dir google-cloud-storage
 pip install --no-cache-dir 'safir[arq,db,gcs] @ git+https://github.com/lsst-sqre/safir@main'
 pip install --no-cache-dir --no-deps .


### PR DESCRIPTION
Add a separate, minimal UWSWorkerConfig dataclass containing the information needed to construct the backend worker, and modify the worker initialization so that it no longer needs to load the main vo-cutouts Config and thus doesn't depend on pydantic-settings.

Plumb execution_duration in the UWS configuration through to the arq worker configuration so that we at least impose the maximum execution duration limit on worker execution. Supporting the per-job configuration will require more work.