### PR TITLE
DM-44720: Improve serialization of task errors

### DIFF
--- a/changelog.d/20240607_143229_rra_DM_44720.md
+++ b/changelog.d/20240607_143229_rra_DM_44720.md
@@ -1,0 +1,3 @@
+### New features
+
+- If the backend image processing code fails with an exception, include a traceback of that exception in the detail portion of the job error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,7 @@ select = ["ALL"]
     "PT012",   # way too aggressive about limiting pytest.raises blocks
     "S101",    # tests should use assert
     "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # one test verifies that exceptions can be pickled
     "SLF001",  # tests are allowed to access private members
 ]
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -118,7 +118,7 @@ sqlalchemy==2.0.30
     #   -r requirements/dev.in
 termcolor==2.4.0
     # via pytest-sugar
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   -c requirements/main.txt
     #   mypy

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -28,4 +28,4 @@ structlog
 
 # Uncomment this, change the branch, comment out safir above, and run make
 # update-deps-no-hashes to test against an unreleased version of Safir.
-safir[arq,db,gcs] @ git+https://github.com/lsst-sqre/safir@main
+safir[arq,db,gcs] @ git+https://github.com/lsst-sqre/safir@tickets/DM-44720

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -57,7 +57,7 @@ google-api-core==2.19.0
     # via
     #   google-cloud-core
     #   google-cloud-storage
-google-auth==2.29.0
+google-auth==2.30.0
     # via
     #   -r requirements/main.in
     #   google-api-core
@@ -173,7 +173,7 @@ rich==13.7.1
     # via typer
 rsa==4.9
     # via google-auth
-safir @ git+https://github.com/lsst-sqre/safir@53062ff688230856f89ce9a82b9ec3036dcb4beb
+safir @ git+https://github.com/lsst-sqre/safir@88363ffeee3b2db60e06b90702b84a7b0daf0ba2
     # via -r requirements/main.in
 shellingham==1.5.4
     # via typer
@@ -196,7 +196,7 @@ structlog==24.2.0
     #   safir
 typer==0.12.3
     # via fastapi-cli
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   fastapi
     #   pydantic

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -34,5 +34,5 @@ scons install declare -t current
 # Install Python dependencies and the vo-cutouts code.
 cd "$1"
 pip install --no-cache-dir google-cloud-storage
-pip install --no-cache-dir 'safir[arq,db,gcs] @ git+https://github.com/lsst-sqre/safir@main'
+pip install --no-cache-dir 'safir[arq,db,gcs] @ git+https://github.com/lsst-sqre/safir@tickets/DM-44720'
 pip install --no-cache-dir --no-deps .

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -26,7 +26,7 @@ set -x
 # alternative (no releases and no tags).
 mkdir /backend
 cd /backend
-git clone --depth 1 -b 0.0.1 https://github.com/lsst-dm/image_cutout_backend.git
+git clone --depth 1 -b tickets/DM-44710 https://github.com/lsst-dm/image_cutout_backend.git
 cd image_cutout_backend
 setup -r .
 scons install declare -t current

--- a/src/vocutouts/uws/models.py
+++ b/src/vocutouts/uws/models.py
@@ -78,7 +78,11 @@ ACTIVE_PHASES = {
 
 
 class ErrorCode(Enum):
-    """Possible error codes in ``text/plain`` SODA errors."""
+    """Possible error codes in ``text/plain`` responses.
+
+    The following list of errors is taken from the SODA specification and
+    therefore may not be appropriate for all DALI services.
+    """
 
     AUTHENTICATION_ERROR = "AuthenticationError"
     AUTHORIZATION_ERROR = "AuthorizationError"

--- a/tests/uws/exceptions_test.py
+++ b/tests/uws/exceptions_test.py
@@ -1,0 +1,65 @@
+"""Tests for UWS exception classes."""
+
+from __future__ import annotations
+
+import pickle
+
+from vocutouts.uws.exceptions import (
+    TaskError,
+    TaskFatalError,
+    TaskTransientError,
+    TaskUserError,
+)
+from vocutouts.uws.models import ErrorCode
+
+
+def test_pickle() -> None:
+    """Test that the `TaskError` exceptions can be pickled.
+
+    Some care has to be taken in defining exceptions to ensure that they can
+    be pickled and unpickled, since `BaseException` provides a ``__reduce__``
+    implementation with somewhat unexpected properties. Make sure that this
+    support doesn't regress, since arq uses pickle to convey errors from
+    backend workers to anything that recovers their results.
+    """
+
+    def nonnegative(arg: int) -> int:
+        if arg < 0:
+            raise ValueError("Negative integers not supported")
+        return arg
+
+    def raise_exception(arg: int, exc_class: type[TaskError]) -> None:
+        try:
+            nonnegative(arg)
+        except Exception as e:
+            raise exc_class(
+                ErrorCode.ERROR,
+                "some message",
+                "some detail",
+                add_traceback=True,
+            ) from e
+
+    for exc_class in (
+        TaskError,
+        TaskFatalError,
+        TaskTransientError,
+        TaskUserError,
+    ):
+        exc: TaskError = exc_class(ErrorCode.ERROR, "some message", "detail")
+        pickled_exc = pickle.loads(pickle.dumps(exc))
+        assert exc.to_job_error() == pickled_exc.to_job_error()
+
+        # Try with tracebacks.
+        try:
+            raise_exception(-1, exc_class)
+        except TaskError as e:
+            exc = e
+        assert exc.traceback
+        assert "nonnegative" in exc.traceback
+        assert "TaskError" not in exc.traceback
+        job_error = exc.to_job_error()
+        assert job_error.detail
+        assert "some detail\n\n" in job_error.detail
+        assert "nonnegative" in job_error.detail
+        pickled_exc = pickle.loads(pickle.dumps(exc))
+        assert exc.to_job_error() == pickled_exc.to_job_error()


### PR DESCRIPTION
Derive `TaskError` from `SlackException` so that eventually we can report unexpected errors to Slack. Rely on `SlackException` to handle serialization support, which is currently on a Safir branch.

Add support for including a traceback of the cause of a `TaskError` exception, and enable that for exceptions from the image cutout backend. Hopefully those exceptions will not contain any security-sensitive information.