### PR TITLE
DM-44763: Take advantage of class serialization

### DIFF
--- a/src/vocutouts/models/stencils.py
+++ b/src/vocutouts/models/stencils.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Self
+from typing import Any, Self, TypeAlias
 
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 
-Range = tuple[float, float]
+Range: TypeAlias = tuple[float, float]
+"""Type representing a range of a coordinate."""
+
+__all__ = [
+    "CircleStencil",
+    "PolygonStencil",
+    "Range",
+    "RangeStencil",
+    "Stencil",
+]
 
 
 class Stencil(ABC):
@@ -22,7 +31,7 @@ class Stencil(ABC):
 
     @abstractmethod
     def to_dict(self) -> dict[str, Any]:
-        """Convert the stencil to a JSON-serializable form for queuing."""
+        """Convert the stencil to a dictionary for logging."""
 
 
 @dataclass
@@ -30,7 +39,10 @@ class CircleStencil(Stencil):
     """Represents a ``CIRCLE`` or ``POS=CIRCLE`` stencil."""
 
     center: SkyCoord
+    """Center of the circle."""
+
     radius: Angle
+    """Radius of the circle."""
 
     @classmethod
     def from_string(cls, params: str) -> Self:
@@ -60,6 +72,7 @@ class PolygonStencil(Stencil):
     """
 
     vertices: SkyCoord
+    """Vertices of the polygon."""
 
     @classmethod
     def from_string(cls, params: str) -> Self:
@@ -90,7 +103,10 @@ class RangeStencil(Stencil):
     """Represents a ``POS=RANGE`` stencil."""
 
     ra: Range
+    """Range of ra values."""
+
     dec: Range
+    """Range of dec values."""
 
     @classmethod
     def from_string(cls, params: str) -> Self:
@@ -106,17 +122,3 @@ class RangeStencil(Stencil):
             "ra": self.ra,
             "dec": self.dec,
         }
-
-
-def parse_stencil(stencil_type: str, params: str) -> Stencil:
-    """Convert a string stencil parameter to its internal representation."""
-    if stencil_type == "POS":
-        stencil_type, params = params.split(None, 1)
-    if stencil_type == "CIRCLE":
-        return CircleStencil.from_string(params)
-    elif stencil_type == "POLYGON":
-        return PolygonStencil.from_string(params)
-    elif stencil_type == "RANGE":
-        return RangeStencil.from_string(params)
-    else:
-        raise ValueError(f"Unknown stencil type {stencil_type}")

--- a/src/vocutouts/policy.py
+++ b/src/vocutouts/policy.py
@@ -33,16 +33,16 @@ class ImageCutoutPolicy(UWSPolicy):
         super().__init__(arq)
         self._logger = logger
 
-    async def dispatch(self, job: UWSJob, access_token: str) -> JobMetadata:
+    async def dispatch(self, job: UWSJob, token: str) -> JobMetadata:
         """Dispatch a cutout request to the backend.
 
         Parameters
         ----------
         job
             The submitted job description.
-        access_token
-            Gafaelfawr access token used to authenticate to Butler server
-            in the backend.
+        token
+            Gafaelfawr token used to authenticate to the Butler server in the
+            backend.
 
         Returns
         -------
@@ -54,13 +54,9 @@ class ImageCutoutPolicy(UWSPolicy):
         Currently, only one dataset ID and only one stencil are supported.
         This limitation is expected to be relaxed in a later version.
         """
-        cutout_params = CutoutParameters.from_job_parameters(job.parameters)
+        params = CutoutParameters.from_job_parameters(job.parameters)
         return await self.arq.enqueue(
-            "cutout",
-            job.job_id,
-            cutout_params.ids,
-            [s.to_dict() for s in cutout_params.stencils],
-            access_token,
+            "cutout", job.job_id, params.ids, params.stencils, token=token
         )
 
     def validate_params(self, params: list[UWSJobParameter]) -> None:

--- a/src/vocutouts/uws/policy.py
+++ b/src/vocutouts/uws/policy.py
@@ -40,7 +40,7 @@ class UWSPolicy(ABC):
         self.arq = arq
 
     @abstractmethod
-    async def dispatch(self, job: UWSJob, access_token: str) -> JobMetadata:
+    async def dispatch(self, job: UWSJob, token: str) -> JobMetadata:
         """Dispatch a job to a backend worker.
 
         This method is responsible for converting UWS job parameters to the
@@ -51,9 +51,9 @@ class UWSPolicy(ABC):
         ----------
         job
             Job to start.
-        access_token
-            Gafaelfawr access token used to authenticate to services used
-            by the backend on the user's behalf.
+        token
+            Gafaelfawr token used to authenticate to services used by the
+            backend on the user's behalf.
 
         Returns
         -------

--- a/src/vocutouts/uws/service.py
+++ b/src/vocutouts/uws/service.py
@@ -226,9 +226,7 @@ class JobService:
             user, phases=phases, after=after, count=count
         )
 
-    async def start(
-        self, user: str, job_id: str, access_token: str
-    ) -> JobMetadata:
+    async def start(self, user: str, job_id: str, token: str) -> JobMetadata:
         """Start execution of a job.
 
         Parameters
@@ -237,9 +235,9 @@ class JobService:
             User on behalf of whom this operation is performed.
         job_id
             Identifier of the job to start.
-        access_token
-            Gafaelfawr access token used to authenticate to services used
-            by the backend on the user's behalf.
+        token
+            Gafaelfawr token used to authenticate to services used by the
+            backend on the user's behalf.
 
         Returns
         -------
@@ -257,7 +255,7 @@ class JobService:
             raise PermissionDeniedError(f"Access to job {job_id} denied")
         if job.phase not in (ExecutionPhase.PENDING, ExecutionPhase.HELD):
             raise InvalidPhaseError("Cannot start job in phase {job.phase}")
-        metadata = await self._policy.dispatch(job, access_token)
+        metadata = await self._policy.dispatch(job, token)
         await self._storage.mark_queued(job_id, metadata)
         return metadata
 

--- a/tests/models/parameters_test.py
+++ b/tests/models/parameters_test.py
@@ -1,0 +1,28 @@
+"""Tests for cutout parameter models."""
+
+from __future__ import annotations
+
+import pickle
+
+from vocutouts.models.parameters import CutoutParameters
+from vocutouts.models.stencils import (
+    CircleStencil,
+    PolygonStencil,
+    RangeStencil,
+)
+
+
+def test_pickle() -> None:
+    params = CutoutParameters(
+        ids=["foo", "bar"],
+        stencils=[
+            CircleStencil.from_string("1 1.42 1"),
+            PolygonStencil.from_string("1 0 1 1 0 1 0 0"),
+            RangeStencil.from_string("-Inf 1 0 1"),
+        ],
+    )
+    params_pickle = pickle.loads(pickle.dumps(params))
+    assert params.ids == params_pickle.ids
+    expected = [s.to_dict() for s in params.stencils]
+    seen = [s.to_dict() for s in params_pickle.stencils]
+    assert expected == seen


### PR DESCRIPTION
Pass cutout parameters to the backend as dataclasses instead of dicts and use this to simplify the code. Add a test to ensure that the parameters will be able to be pickled.

Rename access_token to token, following the terminology that we use elsewhere.