### PR TITLE
DM-44763: Reflect the lack of job cancellation support

### DIFF
--- a/changelog.d/20240613_185120_rra_DM_44763.md
+++ b/changelog.d/20240613_185120_rra_DM_44763.md
@@ -1,0 +1,4 @@
+### Backwards-incompatible changes
+
+- Cancelling or aborting jobs is not supported by the combination of arq and sync worker functions. Properly reflect this in job metadata by forcing execution duration to 0 to indicate that no limit is applied. Substantially increase the default arq job timeout since the timeout will be ineffective anyway.
+- Drop the `CUTOUT_TIMEOUT` configuration option since we have no way of enforcing a timeout on jobs.

--- a/src/vocutouts/config.py
+++ b/src/vocutouts/config.py
@@ -104,11 +104,12 @@ class Config(BaseSettings):
     )
 
     sync_timeout: timedelta = Field(
-        timedelta(minutes=1), title="Timeout for sync requests"
-    )
-
-    timeout: timedelta = Field(
-        timedelta(minutes=10), title="Timeout for cutout jobs"
+        timedelta(minutes=1),
+        title="Timeout for sync requests",
+        description=(
+            "The job will continue running as an async job beyond this"
+            " timeout since cancellation of jobs is not currently supported."
+        ),
     )
 
     tmpdir: Path = Field(Path("/tmp"), title="Temporary directory for workers")
@@ -178,7 +179,7 @@ class Config(BaseSettings):
             )
         return v
 
-    @field_validator("lifetime", "sync_timeout", "timeout", mode="before")
+    @field_validator("lifetime", "sync_timeout", mode="before")
     @classmethod
     def _parse_as_seconds(cls, v: int | str | timedelta) -> int | timedelta:
         """Convert timedelta strings so they are parsed as seconds."""
@@ -213,7 +214,6 @@ class Config(BaseSettings):
         return UWSConfig(
             arq_mode=self.arq_mode,
             arq_redis_settings=self.arq_redis_settings,
-            execution_duration=self.timeout,
             lifetime=self.lifetime,
             parameters_type=CutoutParameters,
             signing_service_account=self.service_account,

--- a/src/vocutouts/uws/config.py
+++ b/src/vocutouts/uws/config.py
@@ -91,13 +91,6 @@ class UWSConfig:
     database_url: str
     """URL for the metadata database."""
 
-    execution_duration: timedelta
-    """Maximum execution time in seconds.
-
-    Jobs that run longer than this length of time will be automatically
-    aborted.
-    """
-
     lifetime: timedelta
     """The lifetime of jobs.
 
@@ -126,6 +119,15 @@ class UWSConfig:
 
     database_password: SecretStr | None = None
     """Password for the database."""
+
+    execution_duration: timedelta = timedelta(seconds=0)
+    """Maximum execution time in seconds.
+
+    Jobs that run longer than this length of time should be automatically
+    aborted. However, currently the backend does not support cancelling jobs,
+    and therefore the only correct value is 0, which indicates that the
+    execution duration of the job is unlimited.
+    """
 
     slack_webhook: SecretStr | None = None
     """Slack incoming webhook for reporting errors."""
@@ -167,8 +169,9 @@ class UWSConfig:
 
     If provided, called with the requested execution duration and the current
     job record and should return the new execution duration time. Otherwise,
-    any execution duration time shorter than the configured maximum timeout
-    will be allowed.
+    the execution duration may not be changed. Note that the current backend
+    does not support cancelling jobs and therefore does not support execution
+    duration values other than 0.
     """
 
     wait_timeout: timedelta = timedelta(minutes=1)

--- a/src/vocutouts/uws/constants.py
+++ b/src/vocutouts/uws/constants.py
@@ -6,11 +6,15 @@ from datetime import timedelta
 
 __all__ = [
     "JOB_RESULT_TIMEOUT",
+    "UWS_DATABASE_TIMEOUT",
     "UWS_QUEUE_NAME",
 ]
 
 JOB_RESULT_TIMEOUT = timedelta(seconds=5)
 """How long to poll arq for job results before giving up."""
+
+UWS_DATABASE_TIMEOUT = timedelta(seconds=30)
+"""Timeout on workers that update the UWS database."""
 
 UWS_QUEUE_NAME = "uws:queue"
 """Name of the arq queue for internal UWS messages."""

--- a/tests/handlers/async_test.py
+++ b/tests/handlers/async_test.py
@@ -26,7 +26,7 @@ PENDING_JOB = """
   <uws:ownerId>someone</uws:ownerId>
   <uws:phase>PENDING</uws:phase>
   <uws:creationTime>[DATE]</uws:creationTime>
-  <uws:executionDuration>600</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>[DATE]</uws:destruction>
   <uws:parameters>
     <uws:parameter id="id" isPost="true">1:2:band:value</uws:parameter>
@@ -50,7 +50,7 @@ COMPLETED_JOB = """
   <uws:creationTime>[DATE]</uws:creationTime>
   <uws:startTime>[DATE]</uws:startTime>
   <uws:endTime>[DATE]</uws:endTime>
-  <uws:executionDuration>600</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>[DATE]</uws:destruction>
   <uws:parameters>
     <uws:parameter id="id" isPost="true">1:2:band:value</uws:parameter>

--- a/tests/support/uws.py
+++ b/tests/support/uws.py
@@ -67,7 +67,6 @@ def build_uws_config() -> UWSConfig:
         async_post_dependency=_post_dependency,
         database_url=database_url,
         database_password=SecretStr(os.environ["POSTGRES_PASSWORD"]),
-        execution_duration=timedelta(minutes=10),
         lifetime=timedelta(days=1),
         parameters_type=SimpleParameters,
         signing_service_account="signer@example.com",

--- a/tests/uws/job_api_test.py
+++ b/tests/uws/job_api_test.py
@@ -33,7 +33,7 @@ PENDING_JOB = """
   <uws:ownerId>user</uws:ownerId>
   <uws:phase>{}</uws:phase>
   <uws:creationTime>{}</uws:creationTime>
-  <uws:executionDuration>{}</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name" isPost="true">Jane</uws:parameter>
@@ -56,7 +56,7 @@ FINISHED_JOB = """
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
   <uws:endTime>{}</uws:endTime>
-  <uws:executionDuration>600</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name" isPost="true">Jane</uws:parameter>
@@ -120,7 +120,6 @@ async def test_job_run(
         "1",
         "PENDING",
         isodatetime(job.creation_time),
-        "600",
         isodatetime(job.creation_time + timedelta(seconds=24 * 60 * 60)),
     )
 
@@ -155,7 +154,6 @@ async def test_job_run(
         "1",
         "QUEUED",
         isodatetime(job.creation_time),
-        "600",
         isodatetime(job.creation_time + timedelta(seconds=24 * 60 * 60)),
     )
     await runner.mark_in_progress("user", "1")
@@ -239,7 +237,6 @@ async def test_job_api(
         "1",
         "PENDING",
         isodatetime(job.creation_time),
-        "600",
         isodatetime(destruction_time),
     )
 
@@ -257,7 +254,7 @@ async def test_job_api(
     )
     assert r.status_code == 200
     assert r.headers["Content-Type"] == "text/plain; charset=utf-8"
-    assert r.text == "600"
+    assert r.text == "0"
 
     r = await client.get(
         "/test/jobs/1/owner", headers={"X-Auth-Request-User": "user"}
@@ -297,6 +294,7 @@ async def test_job_api(
     assert r.status_code == 303
     assert r.headers["Location"] == "https://example.com/test/jobs/1"
 
+    # Changing the execution duration is not supported.
     r = await client.post(
         "/test/jobs/1/executionduration",
         headers={"X-Auth-Request-User": "user"},
@@ -315,7 +313,6 @@ async def test_job_api(
         "1",
         "PENDING",
         isodatetime(job.creation_time),
-        "300",
         isodatetime(now),
     )
 
@@ -346,7 +343,6 @@ async def test_job_api(
         "2",
         "PENDING",
         isodatetime(job.creation_time),
-        "600",
         isodatetime(job.destruction_time),
     )
     r = await client.post(

--- a/tests/uws/job_error_test.py
+++ b/tests/uws/job_error_test.py
@@ -27,7 +27,7 @@ ERRORED_JOB = """
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
   <uws:endTime>{}</uws:endTime>
-  <uws:executionDuration>600</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Sarah</uws:parameter>

--- a/tests/uws/long_polling_test.py
+++ b/tests/uws/long_polling_test.py
@@ -26,7 +26,7 @@ PENDING_JOB = """
   <uws:ownerId>user</uws:ownerId>
   <uws:phase>{}</uws:phase>
   <uws:creationTime>{}</uws:creationTime>
-  <uws:executionDuration>600</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Naomi</uws:parameter>
@@ -47,7 +47,7 @@ EXECUTING_JOB = """
   <uws:phase>EXECUTING</uws:phase>
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
-  <uws:executionDuration>600</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Naomi</uws:parameter>
@@ -69,7 +69,7 @@ FINISHED_JOB = """
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
   <uws:endTime>{}</uws:endTime>
-  <uws:executionDuration>600</uws:executionDuration>
+  <uws:executionDuration>0</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Naomi</uws:parameter>

--- a/tests/uws/workers_test.py
+++ b/tests/uws/workers_test.py
@@ -69,7 +69,6 @@ async def test_build_worker(
     assert settings.functions[0].name == hello.__qualname__
     assert settings.redis_settings == uws_config.arq_redis_settings
     assert settings.queue_name == default_queue_name
-    assert settings.allow_abort_jobs
     assert settings.on_startup
     assert settings.on_shutdown
 
@@ -150,7 +149,6 @@ async def test_build_uws_worker(
     assert callable(job_completed)
     assert settings.redis_settings == uws_config.arq_redis_settings
     assert settings.queue_name == UWS_QUEUE_NAME
-    assert not settings.allow_abort_jobs
     assert settings.on_startup
     assert settings.on_shutdown
 


### PR DESCRIPTION
Unfortunately, there is no way to cancel a sync worker job within arq. ThreadPoolWorker does not offer this functionality, nor does ProcessPoolWorker. We would have to implement our own execution protocol in an external process that we could kill, which would pose cleanup problems.

Reflect this by removing the configuration option for setting a job timeout and forcing the UWS executionduration to 0 by default unless the service supplies a validator for it (in case there are services where the sync backend supports an explicit timeout parameter).

Also remove the vestiges of support for aborting a job, since there is no way to do that either given our worker implementation.