### PR TITLE
DM-44763: Refactor worker exception handling

### DIFF
--- a/changelog.d/20240614_151231_rra_DM_44763.md
+++ b/changelog.d/20240614_151231_rra_DM_44763.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Unknown failures in the worker backend are now recorded as fatal UWS errors rather than transient errors. This is the more conservative choice for unknown exceptions.

--- a/src/vocutouts/uws/storage.py
+++ b/src/vocutouts/uws/storage.py
@@ -322,7 +322,7 @@ class JobStore:
             error = exc.to_job_error()
         else:
             error = UWSJobError(
-                error_type=ErrorType.TRANSIENT,
+                error_type=ErrorType.FATAL,
                 error_code=ErrorCode.ERROR,
                 message="Unknown error executing task",
                 detail=f"{type(exc).__name__}: {exc!s}",

--- a/tests/uws/exceptions_test.py
+++ b/tests/uws/exceptions_test.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import pickle
 
-from vocutouts.uws.exceptions import (
-    TaskError,
-    TaskFatalError,
-    TaskTransientError,
-    TaskUserError,
+from vocutouts.uws.exceptions import TaskError
+from vocutouts.uws.uwsworker import (
+    WorkerError,
+    WorkerFatalError,
+    WorkerTransientError,
+    WorkerUsageError,
 )
-from vocutouts.uws.models import ErrorCode
 
 
 def test_pickle() -> None:
@@ -28,38 +28,42 @@ def test_pickle() -> None:
             raise ValueError("Negative integers not supported")
         return arg
 
-    def raise_exception(arg: int, exc_class: type[TaskError]) -> None:
+    def raise_exception(arg: int, exc_class: type[WorkerError]) -> None:
         try:
             nonnegative(arg)
         except Exception as e:
             raise exc_class(
-                ErrorCode.ERROR,
-                "some message",
-                "some detail",
-                add_traceback=True,
+                "some message", "some detail", add_traceback=True
             ) from e
 
     for exc_class in (
-        TaskError,
-        TaskFatalError,
-        TaskTransientError,
-        TaskUserError,
+        WorkerFatalError,
+        WorkerTransientError,
+        WorkerUsageError,
     ):
-        exc: TaskError = exc_class(ErrorCode.ERROR, "some message", "detail")
+        exc: WorkerError = exc_class("some message", "detail")
         pickled_exc = pickle.loads(pickle.dumps(exc))
-        assert exc.to_job_error() == pickled_exc.to_job_error()
+        task_error = TaskError.from_worker_error(exc)
+        pickled_task_error = TaskError.from_worker_error(pickled_exc)
+        job_error = task_error.to_job_error()
+        assert job_error == pickled_task_error.to_job_error()
+        if exc_class == WorkerUsageError:
+            assert task_error.slack_ignore
+        else:
+            assert not task_error.slack_ignore
 
         # Try with tracebacks.
         try:
             raise_exception(-1, exc_class)
-        except TaskError as e:
+        except WorkerError as e:
             exc = e
         assert exc.traceback
         assert "nonnegative" in exc.traceback
-        assert "TaskError" not in exc.traceback
-        job_error = exc.to_job_error()
+        assert exc_class.__name__ not in exc.traceback
+        job_error = TaskError.from_worker_error(exc).to_job_error()
         assert job_error.detail
         assert "some detail\n\n" in job_error.detail
         assert "nonnegative" in job_error.detail
         pickled_exc = pickle.loads(pickle.dumps(exc))
-        assert exc.to_job_error() == pickled_exc.to_job_error()
+        pickled_task_error = TaskError.from_worker_error(pickled_exc)
+        assert job_error == pickled_task_error.to_job_error()


### PR DESCRIPTION
Separate the exceptions thrown by workers from the code that can translate into UWS job errors and post Slack alerts to reduce the required dependencies for workers. Mark unknown failures as fatal rather than transient, since this is a more conservative guess.