### PR TITLE
DM-44503: Bump science pipelines stack for new Butler

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, arq, and the backend worker definition.
 
-FROM lsstsqre/centos:7-stack-lsst_distrib-w_2024_16
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_2024_26
 
 # Reset the user to root since we need to do system install tasks.
 USER root

--- a/changelog.d/20240628_094800_david.irving_DM_44503.md
+++ b/changelog.d/20240628_094800_david.irving_DM_44503.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Upgrade the science pipelines stack to the latest weekly, to include a new version of daf_butler that includes support for a new version of Butler server with a backwards-incompatible REST API.


### PR DESCRIPTION
Upgrade the science pipelines stack to the latest weekly, to include a new version of daf_butler that includes support for a new version of Butler server, which broke backwards compatibility in the REST API we were using previously.