### PR TITLE
DM-45088: Revert "Bump science pipelines stack for new Butler"

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, arq, and the backend worker definition.
 
-FROM lsstsqre/centos:7-stack-lsst_distrib-w_2024_26
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_2024_16
 
 # Reset the user to root since we need to do system install tasks.
 USER root

--- a/changelog.d/20240701_153719_david.irving_DM_45088.md
+++ b/changelog.d/20240701_153719_david.irving_DM_45088.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Rolled back the science pipelines version due to a Butler bug that makes the new release unusable.


### PR DESCRIPTION
Rolled back the science pipelines version due to a Butler bug that makes the new release unusable.

This reverts commit 48edcf1a4036d0bedd9a40746f05e69c4411ae02.