### PR TITLE
DM-45132: Clean up change log entries, fix worker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,13 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
-##  (2024-06-28)
+## 3.0.0 (2024-06-28)
 
 ### Backwards-incompatible changes
 
 - Cancelling or aborting jobs is not supported by the combination of arq and sync worker functions. Properly reflect this in job metadata by forcing execution duration to 0 to indicate that no limit is applied. Substantially increase the default arq job timeout since the timeout will be ineffective anyway.
 - Drop the `CUTOUT_TIMEOUT` configuration option since we have no way of enforcing a timeout on jobs.
-
-- Upgrade the science pipelines stack to the latest weekly, to include a new version of daf_butler that includes support for a new version of Butler server with a backwards-incompatible REST API.
+- Upgrade the base image for the backend worker to the latest weekly. This includes a new version of `lsst.daf.butler`, which targets a new version of the Butler server with a backwards-incompatible REST API.
 
 ### New features
 

--- a/changelog.d/20240701_153719_david.irving_DM_45088.md
+++ b/changelog.d/20240701_153719_david.irving_DM_45088.md
@@ -1,3 +1,3 @@
 ### Backwards-incompatible changes
 
-- Rolled back the science pipelines version due to a Butler bug that makes the new release unusable.
+- Rolled back the base image for the backend worker due to a Butler bug that makes the new release unusable.

--- a/changelog.d/20240705_101725_rra_DM_45132.md
+++ b/changelog.d/20240705_101725_rra_DM_45132.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Stop upgrading the operating system packages in the worker image because the base image is so old that the package repositories no longer exist. This will hopefully be fixed in a future release of the Science Pipelines base image based on AlmaLinux.

--- a/scripts/install-worker-packages.sh
+++ b/scripts/install-worker-packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Upgrade the CentOS packages in worker images.  This is done in a separate
+# Upgrade the CentOS packages in worker images. This is done in a separate
 # script to create a separate cached Docker image, which will help with
 # iteration speed on the more interesting setup actions taken later in the
 # build.
@@ -14,5 +14,9 @@ set -euo pipefail
 set -x
 
 # Upgrade the Red Hat packages.
-yum -y upgrade
-yum clean all
+#
+# TODO(rra): Disabled for now because the version of CentOS used by the image
+# is so old that the package repositories no longer exist. This will in theory
+# soon be fixed by basing the image on AlmaLinux.
+#yum -y upgrade
+#yum clean all


### PR DESCRIPTION
Add a proper version number for the 3.0.0 release and reword some of the changes for additional clarity.

Stop upgrading packages in the worker image since the base image is so old that the package repositories no longer exist.