### PR TITLE
DM-45138: Add an arq cron job to delete expired jobs

### DIFF
--- a/changelog.d/20240708_165945_rra_DM_45138.md
+++ b/changelog.d/20240708_165945_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### New features
+
+- The database worker pod now deletes the records for all jobs that have passed their destruction times once per hour.

--- a/src/vocutouts/uws/constants.py
+++ b/src/vocutouts/uws/constants.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from arq.cron import Options
+
 __all__ = [
     "JOB_RESULT_TIMEOUT",
     "UWS_DATABASE_TIMEOUT",
+    "UWS_EXPIRE_JOBS_SCHEDULE",
     "UWS_QUEUE_NAME",
 ]
 
@@ -15,6 +18,17 @@ JOB_RESULT_TIMEOUT = timedelta(seconds=5)
 
 UWS_DATABASE_TIMEOUT = timedelta(seconds=30)
 """Timeout on workers that update the UWS database."""
+
+UWS_EXPIRE_JOBS_SCHEDULE = Options(
+    month=None,
+    day=None,
+    weekday=None,
+    hour=None,
+    minute=5,
+    second=0,
+    microsecond=0,
+)
+"""Schedule for job expiration cron job, as `arq.cron.cron` parameters."""
 
 UWS_QUEUE_NAME = "uws:queue"
 """Name of the arq queue for internal UWS messages."""

--- a/src/vocutouts/uws/service.py
+++ b/src/vocutouts/uws/service.py
@@ -121,17 +121,13 @@ class JobService:
         logger.info("Created job")
         return job
 
-    async def delete(
-        self,
-        user: str,
-        job_id: str,
-    ) -> None:
+    async def delete(self, user: str, job_id: str) -> None:
         """Delete a job.
 
         The UWS standard says that deleting a job should stop the in-progress
-        work, but Dramatiq doesn't provide a way to do that.  Settle for
-        deleting the database entry, which will cause the task to throw away
-        the results when it finishes.
+        work, but arq, although it supports job cancellation, cannot cancel
+        sync jobs. Settle for deleting the database entry, which will cause
+        the task to throw away the results when it finishes.
         """
         job = await self._storage.get(job_id)
         if job.owner != user:

--- a/src/vocutouts/uws/uwsworker.py
+++ b/src/vocutouts/uws/uwsworker.py
@@ -16,6 +16,7 @@ from urllib.parse import urlsplit
 from arq import func
 from arq.connections import RedisSettings
 from arq.constants import default_queue_name
+from arq.cron import CronJob
 from arq.typing import SecondsTimedelta, StartupShutdown, WorkerCoroutine
 from arq.worker import Function
 from pydantic import BaseModel
@@ -106,6 +107,9 @@ class WorkerSettings:
 
     on_shutdown: StartupShutdown | None = None
     """Coroutine to run on shutdown."""
+
+    cron_jobs: Sequence[CronJob] | None = None
+    """Cron jobs to run."""
 
 
 @dataclass


### PR DESCRIPTION
Delete all jobs whose destruction date has passed from the UWS database via an arq cron job that runs once per hour.