### PR TITLE
DM-45138: Add a colon after the error code

### DIFF
--- a/changelog.d/20240709_104843_rra_DM_45138.md
+++ b/changelog.d/20240709_104843_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add a colon after the error code and before the error message in error replies.

--- a/src/vocutouts/uws/errors.py
+++ b/src/vocutouts/uws/errors.py
@@ -19,7 +19,7 @@ __all__ = ["install_error_handlers"]
 async def _uws_error_handler(
     request: Request, exc: UWSError
 ) -> PlainTextResponse:
-    response = f"{exc.error_code.value} {exc!s}\n"
+    response = f"{exc.error_code.value}: {exc!s}\n"
     if exc.detail:
         response += "\n{exc.detail}"
     return PlainTextResponse(response, status_code=exc.status_code)


### PR DESCRIPTION
The standard allows a colon after the error code and before the message in plain-text error replies. Make use of this to make the errors a bit more human-readable.