### PR TITLE
DM-45138: Finish the worker and API model separation

### DIFF
--- a/src/vocutouts/models/cutout.py
+++ b/src/vocutouts/models/cutout.py
@@ -181,7 +181,7 @@ class RangeStencil(Stencil):
         )
 
 
-class CutoutParameters(ParametersModel):
+class CutoutParameters(ParametersModel[WorkerCutout]):
     """Parameters to a cutout request."""
 
     ids: list[str] = Field(
@@ -255,7 +255,7 @@ class CutoutParameters(ParametersModel):
         except ValidationError as e:
             raise InvalidCutoutParameterError(str(e), params) from e
 
-    def to_worker_cutout(self) -> WorkerCutout:
+    def to_worker_parameters(self) -> WorkerCutout:
         """Convert to the domain model used by the backend worker."""
         stencils = [s.to_worker_stencil() for s in self.stencils]
         return WorkerCutout(dataset_ids=self.ids, stencils=stencils)

--- a/src/vocutouts/uws/config.py
+++ b/src/vocutouts/uws/config.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Self, TypeAlias
+from typing import Generic, Self, TypeAlias, TypeVar
 
 from arq.connections import RedisSettings
 from pydantic import BaseModel, SecretStr
@@ -27,6 +27,9 @@ ParametersDependency: TypeAlias = Callable[
 ]
 """Type for a dependency that gathers parameters for a job."""
 
+T = TypeVar("T", bound=BaseModel)
+"""Generic type for the worker parameters."""
+
 __all__ = [
     "DestructionValidator",
     "ExecutionDurationValidator",
@@ -36,7 +39,7 @@ __all__ = [
 ]
 
 
-class ParametersModel(BaseModel, ABC):
+class ParametersModel(BaseModel, ABC, Generic[T]):
     """Defines the interface for a model suitable for job parameters."""
 
     @classmethod
@@ -63,6 +66,10 @@ class ParametersModel(BaseModel, ABC):
         pydantic.ValidationError
             Raised if the parameters do not validate.
         """
+
+    @abstractmethod
+    def to_worker_parameters(self) -> T:
+        """Convert to the domain model used by the backend worker."""
 
 
 @dataclass

--- a/tests/handlers/async_test.py
+++ b/tests/handlers/async_test.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from safir.testing.slack import MockSlackWebhook
 
+from vocutouts.models.domain.cutout import WorkerCutout
 from vocutouts.uws.models import UWSJobResult
 
 from ..support.uws import MockJobRunner
@@ -96,6 +97,8 @@ async def test_create_job(client: AsyncClient, runner: MockJobRunner) -> None:
     assert r.headers["Location"] == "https://example.com/api/cutout/jobs/2"
 
     async def run_job() -> None:
+        arq_job = await runner.get_job_metadata("someone", "2")
+        assert isinstance(arq_job.args[0], WorkerCutout)
         await runner.mark_in_progress("someone", "2", delay=0.2)
         results = [
             UWSJobResult(

--- a/tests/models/domain/cutout_test.py
+++ b/tests/models/domain/cutout_test.py
@@ -16,11 +16,11 @@ def test_pickle() -> None:
         CutoutParameters(
             ids=["foo"],
             stencils=[CircleStencil.from_string("1 1.42 1")],
-        ).to_worker_cutout(),
+        ).to_worker_parameters(),
         CutoutParameters(
             ids=["foo"],
             stencils=[PolygonStencil.from_string("1 0 1 1 0 1 0 0")],
-        ).to_worker_cutout(),
+        ).to_worker_parameters(),
     ):
         cutout_pickle = pickle.loads(pickle.dumps(cutout))
         assert cutout.dataset_ids == cutout_pickle.dataset_ids


### PR DESCRIPTION
The previous change defined separate worker and API models, but still passed the API model to the backend worker even though it now expected the worker model. Finish the conversion, which requires a bit more typing work and a new required method for ParametersModel. Add tests that the arguments to the backend worker are what we expect them to be.