### PR TITLE
DM-45138: Fix the names of the UWS worker functions

### DIFF
--- a/src/vocutouts/uws/uwsworker.py
+++ b/src/vocutouts/uws/uwsworker.py
@@ -361,14 +361,14 @@ def build_worker(
         if info.run_id:
             logger = logger.bind(run_id=info.run_id)
 
-        await arq.enqueue("job_started", info.job_id, datetime.now(tz=UTC))
+        await arq.enqueue("uws_job_started", info.job_id, datetime.now(tz=UTC))
         loop = asyncio.get_running_loop()
         try:
             return await loop.run_in_executor(
                 pool, worker, params, info, logger
             )
         finally:
-            await arq.enqueue("job_completed", info.job_id)
+            await arq.enqueue("uws_job_completed", info.job_id)
 
     # Job timeouts are not actually supported since we have no way of stopping
     # the sync worker. A timeout will just leave the previous worker running

--- a/tests/uws/workers_test.py
+++ b/tests/uws/workers_test.py
@@ -99,7 +99,7 @@ async def test_build_worker(
     assert list(arq._job_metadata[UWS_QUEUE_NAME].values()) == [
         JobMetadata(
             id=ANY,
-            name="job_started",
+            name="uws_job_started",
             args=("42", ANY),
             kwargs={},
             enqueue_time=ANY,
@@ -108,7 +108,7 @@ async def test_build_worker(
         ),
         JobMetadata(
             id=ANY,
-            name="job_completed",
+            name="uws_job_completed",
             args=("42",),
             kwargs={},
             enqueue_time=ANY,


### PR DESCRIPTION
When refactoring, I added a uws_ prefix to the names of the database worker functions but didn't reflect that in the dispatched jobs from the main worker. Fix the latter to also use the uws_ prefix.