### PR TITLE
DM-45138: Add timeout support

### DIFF
--- a/changelog.d/20240710_144457_rra_DM_45138.md
+++ b/changelog.d/20240710_144457_rra_DM_45138.md
@@ -1,0 +1,4 @@
+### New features
+
+- Restore support for execution duration and change the default execution duration back to 10 minutes. Use a very ugly hack to enforce a timeout in the backend worker that will hopefully not be too fragile.
+- Re-add the `CUTOUT_TIMEOUT` configuration option to change the default and maximum execution duration for cutout jobs.

--- a/src/vocutouts/config.py
+++ b/src/vocutouts/config.py
@@ -105,12 +105,11 @@ class Config(BaseSettings):
     )
 
     sync_timeout: timedelta = Field(
-        timedelta(minutes=1),
-        title="Timeout for sync requests",
-        description=(
-            "The job will continue running as an async job beyond this"
-            " timeout since cancellation of jobs is not currently supported."
-        ),
+        timedelta(minutes=1), title="Timeout for sync requests"
+    )
+
+    timeout: timedelta = Field(
+        timedelta(minutes=10), title="Timeout for cutout jobs"
     )
 
     tmpdir: Path = Field(Path("/tmp"), title="Temporary directory for workers")
@@ -180,7 +179,7 @@ class Config(BaseSettings):
             )
         return v
 
-    @field_validator("lifetime", "sync_timeout", mode="before")
+    @field_validator("lifetime", "sync_timeout", "timeout", mode="before")
     @classmethod
     def _parse_timedelta(cls, v: str | float | timedelta) -> float | timedelta:
         """Support human-readable timedeltas."""
@@ -211,6 +210,7 @@ class Config(BaseSettings):
         return UWSConfig(
             arq_mode=self.arq_mode,
             arq_redis_settings=self.arq_redis_settings,
+            execution_duration=self.timeout,
             lifetime=self.lifetime,
             parameters_type=CutoutParameters,
             signing_service_account=self.service_account,

--- a/src/vocutouts/uws/config.py
+++ b/src/vocutouts/uws/config.py
@@ -98,6 +98,13 @@ class UWSConfig:
     database_url: str
     """URL for the metadata database."""
 
+    execution_duration: timedelta
+    """Maximum execution time in seconds.
+
+    Jobs that run longer than this length of time will be automatically
+    aborted.
+    """
+
     lifetime: timedelta
     """The lifetime of jobs.
 
@@ -126,15 +133,6 @@ class UWSConfig:
 
     database_password: SecretStr | None = None
     """Password for the database."""
-
-    execution_duration: timedelta = timedelta(seconds=0)
-    """Maximum execution time in seconds.
-
-    Jobs that run longer than this length of time should be automatically
-    aborted. However, currently the backend does not support cancelling jobs,
-    and therefore the only correct value is 0, which indicates that the
-    execution duration of the job is unlimited.
-    """
 
     slack_webhook: SecretStr | None = None
     """Slack incoming webhook for reporting errors."""
@@ -176,9 +174,7 @@ class UWSConfig:
 
     If provided, called with the requested execution duration and the current
     job record and should return the new execution duration time. Otherwise,
-    the execution duration may not be changed. Note that the current backend
-    does not support cancelling jobs and therefore does not support execution
-    duration values other than 0.
+    the execution duration may not be changed.
     """
 
     wait_timeout: timedelta = timedelta(minutes=1)

--- a/src/vocutouts/uws/service.py
+++ b/src/vocutouts/uws/service.py
@@ -432,15 +432,13 @@ class JobService:
         if job.owner != user:
             raise PermissionDeniedError(f"Access to job {job_id} denied")
 
-        # Validate the new value. Only support changes to execution duration
-        # if a validator is set, which is a signal that the application
-        # supports cancellation of jobs. The current implementation does not
-        # support cancelling jobs and therefore cannot enforce a timeout, so
-        # an execution duration of 0 is currently the only correct value.
+        # Validate the new value.
         if validator := self._config.validate_execution_duration:
             duration = validator(duration, job)
-        else:
-            return None
+        if duration > self._config.execution_duration:
+            duration = self._config.execution_duration
+
+        # Update the duration in the job.
         if duration == job.execution_duration:
             return None
         await self._storage.update_execution_duration(job_id, duration)

--- a/tests/handlers/async_test.py
+++ b/tests/handlers/async_test.py
@@ -27,7 +27,7 @@ PENDING_JOB = """
   <uws:ownerId>someone</uws:ownerId>
   <uws:phase>PENDING</uws:phase>
   <uws:creationTime>[DATE]</uws:creationTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>600</uws:executionDuration>
   <uws:destruction>[DATE]</uws:destruction>
   <uws:parameters>
     <uws:parameter id="id" isPost="true">1:2:band:value</uws:parameter>
@@ -51,7 +51,7 @@ COMPLETED_JOB = """
   <uws:creationTime>[DATE]</uws:creationTime>
   <uws:startTime>[DATE]</uws:startTime>
   <uws:endTime>[DATE]</uws:endTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>600</uws:executionDuration>
   <uws:destruction>[DATE]</uws:destruction>
   <uws:parameters>
     <uws:parameter id="id" isPost="true">1:2:band:value</uws:parameter>

--- a/tests/support/uws.py
+++ b/tests/support/uws.py
@@ -74,6 +74,7 @@ def build_uws_config() -> UWSConfig:
         async_post_dependency=_post_dependency,
         database_url=database_url,
         database_password=SecretStr(os.environ["POSTGRES_PASSWORD"]),
+        execution_duration=timedelta(minutes=10),
         lifetime=timedelta(days=1),
         parameters_type=SimpleParameters,
         signing_service_account="signer@example.com",

--- a/tests/uws/job_api_test.py
+++ b/tests/uws/job_api_test.py
@@ -37,7 +37,7 @@ PENDING_JOB = """
   <uws:ownerId>user</uws:ownerId>
   <uws:phase>{}</uws:phase>
   <uws:creationTime>{}</uws:creationTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>{}</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name" isPost="true">Jane</uws:parameter>
@@ -60,7 +60,7 @@ FINISHED_JOB = """
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
   <uws:endTime>{}</uws:endTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>{}</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name" isPost="true">Jane</uws:parameter>
@@ -127,6 +127,7 @@ async def test_job_run(
         "1",
         "PENDING",
         isodatetime(job.creation_time),
+        "600",
         isodatetime(job.creation_time + timedelta(seconds=24 * 60 * 60)),
     )
 
@@ -161,6 +162,7 @@ async def test_job_run(
         "1",
         "QUEUED",
         isodatetime(job.creation_time),
+        "600",
         isodatetime(job.creation_time + timedelta(seconds=24 * 60 * 60)),
     )
     await runner.mark_in_progress("user", "1")
@@ -207,6 +209,7 @@ async def test_job_run(
         isodatetime(job.creation_time),
         isodatetime(job.start_time),
         isodatetime(job.end_time),
+        "600",
         isodatetime(job.creation_time + timedelta(seconds=24 * 60 * 60)),
     )
 
@@ -261,6 +264,7 @@ async def test_job_api(
         "1",
         "PENDING",
         isodatetime(job.creation_time),
+        "600",
         isodatetime(destruction_time),
     )
 
@@ -278,7 +282,7 @@ async def test_job_api(
     )
     assert r.status_code == 200
     assert r.headers["Content-Type"] == "text/plain; charset=utf-8"
-    assert r.text == "0"
+    assert r.text == "600"
 
     r = await client.get(
         "/test/jobs/1/owner", headers={"X-Auth-Request-User": "user"}
@@ -318,7 +322,6 @@ async def test_job_api(
     assert r.status_code == 303
     assert r.headers["Location"] == "https://example.com/test/jobs/1"
 
-    # Changing the execution duration is not supported.
     r = await client.post(
         "/test/jobs/1/executionduration",
         headers={"X-Auth-Request-User": "user"},
@@ -337,6 +340,7 @@ async def test_job_api(
         "1",
         "PENDING",
         isodatetime(job.creation_time),
+        "300",
         isodatetime(now),
     )
 
@@ -367,6 +371,7 @@ async def test_job_api(
         "2",
         "PENDING",
         isodatetime(job.creation_time),
+        "600",
         isodatetime(job.destruction_time),
     )
     r = await client.post(

--- a/tests/uws/job_error_test.py
+++ b/tests/uws/job_error_test.py
@@ -28,7 +28,7 @@ ERRORED_JOB = """
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
   <uws:endTime>{}</uws:endTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>600</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Sarah</uws:parameter>

--- a/tests/uws/long_polling_test.py
+++ b/tests/uws/long_polling_test.py
@@ -26,7 +26,7 @@ PENDING_JOB = """
   <uws:ownerId>user</uws:ownerId>
   <uws:phase>{}</uws:phase>
   <uws:creationTime>{}</uws:creationTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>600</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Naomi</uws:parameter>
@@ -47,7 +47,7 @@ EXECUTING_JOB = """
   <uws:phase>EXECUTING</uws:phase>
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>600</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Naomi</uws:parameter>
@@ -69,7 +69,7 @@ FINISHED_JOB = """
   <uws:creationTime>{}</uws:creationTime>
   <uws:startTime>{}</uws:startTime>
   <uws:endTime>{}</uws:endTime>
-  <uws:executionDuration>0</uws:executionDuration>
+  <uws:executionDuration>600</uws:executionDuration>
   <uws:destruction>{}</uws:destruction>
   <uws:parameters>
     <uws:parameter id="name">Naomi</uws:parameter>


### PR DESCRIPTION
Switch the backend worker to ProcessPoolExecutor and use a really ugly hack to terminate the worker process and rebuild the pool on timeout or job cancellation.

Restore support for execution duration, change the default execution duration back to 10 minutes, and re-add the CUTOUT_TIMEOUT environment variable setting to change the default timeout.