### PR TITLE
DM-45138: Restore parsing of seconds as a string

### DIFF
--- a/changelog.d/20240710_155859_rra_DM_45138.md
+++ b/changelog.d/20240710_155859_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Allow time durations in the configuration to be given in number of seconds as a string, which was accidentally broken in 3.0.0.

--- a/src/vocutouts/config.py
+++ b/src/vocutouts/config.py
@@ -109,7 +109,11 @@ class Config(BaseSettings):
     )
 
     timeout: timedelta = Field(
-        timedelta(minutes=10), title="Timeout for cutout jobs"
+        timedelta(minutes=10),
+        title="Cutout job timeout in seconds",
+        description=(
+            "Must be given as a number of seconds as a string or integer"
+        ),
     )
 
     tmpdir: Path = Field(Path("/tmp"), title="Temporary directory for workers")
@@ -179,13 +183,16 @@ class Config(BaseSettings):
             )
         return v
 
-    @field_validator("lifetime", "sync_timeout", "timeout", mode="before")
+    @field_validator("lifetime", "sync_timeout", mode="before")
     @classmethod
     def _parse_timedelta(cls, v: str | float | timedelta) -> float | timedelta:
         """Support human-readable timedeltas."""
         if not isinstance(v, str):
             return v
-        return parse_timedelta(v)
+        try:
+            return int(v)
+        except ValueError:
+            return parse_timedelta(v)
 
     @property
     def arq_redis_settings(self) -> RedisSettings:


### PR DESCRIPTION
Allow the timedelta configuration parameters to take a number of seconds as a string. Remove the validator for timeout, since it has to be parsed by the cutout worker without using pydantic-settings and therefore must be a simple number of seconds.