### PR TITLE
DM-45138: Fix parsing of string number of seconds for timeout

### DIFF
--- a/src/vocutouts/config.py
+++ b/src/vocutouts/config.py
@@ -194,6 +194,16 @@ class Config(BaseSettings):
         except ValueError:
             return parse_timedelta(v)
 
+    @field_validator("timeout", mode="before")
+    @classmethod
+    def _parse_timedelta_seconds(
+        cls, v: str | float | timedelta
+    ) -> float | timedelta:
+        """Support human-readable timedeltas."""
+        if not isinstance(v, str):
+            return v
+        return int(v)
+
     @property
     def arq_redis_settings(self) -> RedisSettings:
         """Redis settings for arq."""


### PR DESCRIPTION
Pydantic's built-in timedelta parsing does not support seconds as a string, so add a validator to handle (and force) that.