### PR TITLE
DM-45138: Remove dependency on ResultStore from JobService

### DIFF
--- a/src/vocutouts/uws/dependencies.py
+++ b/src/vocutouts/uws/dependencies.py
@@ -80,7 +80,6 @@ class UWSFactory:
             config=self._config,
             arq_queue=self._arq,
             storage=self.create_job_store(),
-            result_store=self._result_store,
             logger=self._logger,
         )
 

--- a/src/vocutouts/uws/handlers.py
+++ b/src/vocutouts/uws/handlers.py
@@ -538,9 +538,11 @@ def install_sync_post_handler(
         uws_factory: Annotated[UWSFactory, Depends(uws_dependency)],
     ) -> str:
         job_service = uws_factory.create_job_service()
-        return await job_service.run_sync(
+        result_store = uws_factory.create_result_store()
+        result = await job_service.run_sync(
             user, params, token=token, runid=runid
         )
+        return result_store.sign_url(result).url
 
 
 def install_sync_get_handler(
@@ -581,6 +583,8 @@ def install_sync_get_handler(
         uws_factory: Annotated[UWSFactory, Depends(uws_dependency)],
     ) -> str:
         job_service = uws_factory.create_job_service()
-        return await job_service.run_sync(
+        result_store = uws_factory.create_result_store()
+        result = await job_service.run_sync(
             user, params, token=token, runid=runid
         )
+        return result_store.sign_url(result).url

--- a/src/vocutouts/uws/models.py
+++ b/src/vocutouts/uws/models.py
@@ -22,7 +22,7 @@ __all__ = [
     "UWSJobError",
     "UWSJobParameter",
     "UWSJobResult",
-    "UWSJobResultURL",
+    "UWSJobResultSigned",
 ]
 
 
@@ -144,11 +144,11 @@ class UWSJobResult:
 
 
 @dataclass
-class UWSJobResultURL:
+class UWSJobResultSigned:
     """A single result from the job with a signed URL.
 
-    A `UWSJobResult` is converted to a `UWSJobResultURL` before generating the
-    response via templating.
+    A `UWSJobResult` is converted to a `UWSJobResultSigned` before generating
+    the response via templating or returning the URL as a redirect.
     """
 
     result_id: str

--- a/src/vocutouts/uws/responses.py
+++ b/src/vocutouts/uws/responses.py
@@ -51,9 +51,7 @@ class UWSTemplates:
 
     async def job(self, request: Request, job: UWSJob) -> Response:
         """Return a job as an XML response."""
-        results = [
-            await self._result_store.url_for_result(r) for r in job.results
-        ]
+        results = [self._result_store.sign_url(r) for r in job.results]
         return _templates.TemplateResponse(
             request,
             "job.xml",
@@ -83,9 +81,7 @@ class UWSTemplates:
 
     async def results(self, request: Request, job: UWSJob) -> Response:
         """Return the results for a job as an XML response."""
-        results = [
-            await self._result_store.url_for_result(r) for r in job.results
-        ]
+        results = [self._result_store.sign_url(r) for r in job.results]
         return _templates.TemplateResponse(
             request,
             "results.xml",

--- a/src/vocutouts/uws/results.py
+++ b/src/vocutouts/uws/results.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from safir.gcs import SignedURLService
 
 from .config import UWSConfig
-from .models import UWSJobResult, UWSJobResultURL
+from .models import UWSJobResult, UWSJobResultSigned
 
 __all__ = ["ResultStore"]
 
@@ -31,7 +31,7 @@ class ResultStore:
             lifetime=config.url_lifetime,
         )
 
-    async def url_for_result(self, result: UWSJobResult) -> UWSJobResultURL:
+    def sign_url(self, result: UWSJobResult) -> UWSJobResultSigned:
         """Convert a job result into a signed URL.
 
         Notes
@@ -48,7 +48,7 @@ class ResultStore:
         longer-lived object to hold the credentials.
         """
         signed_url = self._url_service.signed_url(result.url, result.mime_type)
-        return UWSJobResultURL(
+        return UWSJobResultSigned(
             result_id=result.result_id,
             url=signed_url,
             size=result.size,


### PR DESCRIPTION
In preparation for using the JobService more from the database worker, remove the dependency on ResultStore (which requires GCS credentials) at the minor cost of a bit of additional complexity in the handlers. Use a better name for the model holding a job result with a signed URL.