### PR TITLE
DM-45138: Move availability handler into UWS library

### DIFF
--- a/src/vocutouts/handlers/external.py
+++ b/src/vocutouts/handlers/external.py
@@ -5,15 +5,12 @@ to create a new job has to be provided by the application since only the
 application knows the job parameters.
 """
 
-from typing import Annotated
-
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Request, Response
 from safir.metadata import get_metadata
 from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..config import config
 from ..models.index import Index
-from ..uws.dependencies import UWSFactory, uws_dependency
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all external handlers."""
@@ -73,22 +70,6 @@ async def get_index() -> Index:
         application_name=config.name,
     )
     return Index(metadata=metadata)
-
-
-@router.get(
-    "/availability",
-    description="VOSI-availability resource for the image cutout service",
-    responses={200: {"content": {"application/xml": {}}}},
-    summary="IVOA service availability",
-)
-async def get_availability(
-    request: Request,
-    uws_factory: Annotated[UWSFactory, Depends(uws_dependency)],
-) -> Response:
-    job_service = uws_factory.create_job_service()
-    availability = await job_service.availability()
-    templates = uws_factory.create_templates()
-    return templates.availability(request, availability)
 
 
 @router.get(

--- a/src/vocutouts/uws/app.py
+++ b/src/vocutouts/uws/app.py
@@ -22,6 +22,7 @@ from .constants import (
 from .exceptions import UWSError
 from .handlers import (
     install_async_post_handler,
+    install_availability_handler,
     install_sync_get_handler,
     install_sync_post_handler,
     uws_router,
@@ -169,6 +170,7 @@ class UWSApplication:
         ``/sync`` to create a sync job will be added.
         """
         router.include_router(uws_router, prefix="/jobs")
+        install_availability_handler(router)
         if route := self._config.sync_get_route:
             install_sync_get_handler(router, route)
         if route := self._config.sync_post_route:

--- a/src/vocutouts/uws/models.py
+++ b/src/vocutouts/uws/models.py
@@ -23,7 +23,6 @@ from vo_models.uws.types import ErrorType, ExecutionPhase, UWSVersion
 
 __all__ = [
     "ACTIVE_PHASES",
-    "Availability",
     "ErrorCode",
     "UWSJob",
     "UWSJobDescription",
@@ -32,17 +31,6 @@ __all__ = [
     "UWSJobResult",
     "UWSJobResultSigned",
 ]
-
-
-@dataclass
-class Availability:
-    """Availability information (from VOSI)."""
-
-    available: bool
-    """Whether the service appears to be available."""
-
-    note: str | None = None
-    """Supplemental information, usually when the service is not available."""
 
 
 ACTIVE_PHASES = {

--- a/src/vocutouts/uws/responses.py
+++ b/src/vocutouts/uws/responses.py
@@ -7,7 +7,7 @@ from fastapi import Request, Response
 from fastapi.templating import Jinja2Templates
 from safir.datetime import isodatetime
 
-from .models import Availability, UWSJob, UWSJobError
+from .models import UWSJob, UWSJobError
 from .results import ResultStore
 
 __all__ = ["UWSTemplates"]
@@ -29,17 +29,6 @@ class UWSTemplates:
 
     def __init__(self, result_store: ResultStore) -> None:
         self._result_store = result_store
-
-    def availability(
-        self, request: Request, availability: Availability
-    ) -> Response:
-        """Return the availability of a service as an XML response."""
-        return _templates.TemplateResponse(
-            request,
-            "availability.xml",
-            {"availability": availability},
-            media_type="application/xml",
-        )
 
     def error(self, request: Request, error: UWSJobError) -> Response:
         """Return the error of a job as an XML response."""

--- a/src/vocutouts/uws/service.py
+++ b/src/vocutouts/uws/service.py
@@ -9,6 +9,7 @@ from safir.arq import ArqQueue, JobMetadata
 from safir.datetime import current_datetime, isodatetime
 from structlog.stdlib import BoundLogger
 from vo_models.uws.types import ExecutionPhase
+from vo_models.vosi.availability import Availability
 
 from .config import ParametersModel, UWSConfig
 from .constants import JOB_STOP_TIMEOUT
@@ -21,7 +22,6 @@ from .exceptions import (
 )
 from .models import (
     ACTIVE_PHASES,
-    Availability,
     UWSJob,
     UWSJobDescription,
     UWSJobParameter,
@@ -103,13 +103,12 @@ class JobService:
     async def availability(self) -> Availability:
         """Check whether the service is up.
 
-        Used for ``/availability`` endpoints.  Currently this only checks the
-        database.  Eventually it should push an end-to-end test through the
-        job execution system.
+        Used for ``/availability`` endpoints. Currently this only checks the
+        database.
 
         Returns
         -------
-        vocutouts.uws.models.Availability
+        Availability
             Service availability information.
         """
         return await self._storage.availability()

--- a/src/vocutouts/uws/storage.py
+++ b/src/vocutouts/uws/storage.py
@@ -15,10 +15,10 @@ from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.ext.asyncio import async_scoped_session
 from sqlalchemy.future import select
 from vo_models.uws.types import ErrorType, ExecutionPhase
+from vo_models.vosi.availability import Availability
 
 from .exceptions import TaskError, UnknownJobError
 from .models import (
-    Availability,
     ErrorCode,
     UWSJob,
     UWSJobDescription,

--- a/src/vocutouts/uws/templates/availability.xml
+++ b/src/vocutouts/uws/templates/availability.xml
@@ -1,6 +1,0 @@
-<vosi:availability xmlns:vosi="http://www.ivoa.net/xml/VOSIAvailability/v1.0">
-  <vosi:available>{% if availability.available %}true{% else %}false{% endif %}</vosi:available>
-  {%- if availability.note %}
-  <vosi:note>{availability.note}</vosi:note>
-  {%- endif %}
-</vosi:availability>

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -8,12 +8,6 @@ from httpx import ASGITransport, AsyncClient
 
 from vocutouts.config import config
 
-AVAILABILITY = """
-<vosi:availability xmlns:vosi="http://www.ivoa.net/xml/VOSIAvailability/v1.0">
-  <vosi:available>true</vosi:available>
-</vosi:availability>
-"""
-
 CAPABILITIES = """
 <?xml version="1.0"?>
 <capabilities
@@ -58,13 +52,6 @@ async def test_get_index(client: AsyncClient) -> None:
     assert isinstance(metadata["description"], str)
     assert isinstance(metadata["repository_url"], str)
     assert isinstance(metadata["documentation_url"], str)
-
-
-@pytest.mark.asyncio
-async def test_availability(client: AsyncClient) -> None:
-    r = await client.get("/api/cutout/availability")
-    assert r.status_code == 200
-    assert r.text == AVAILABILITY.strip()
 
 
 @pytest.mark.asyncio

--- a/tests/uws/vosi_test.py
+++ b/tests/uws/vosi_test.py
@@ -1,0 +1,20 @@
+"""Tests for VOSI functionality provided by the UWS library."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from vo_models.vosi.availability import Availability
+
+AVAILABILITY = """
+<vosi:availability xmlns:vosi="http://www.ivoa.net/xml/VOSIAvailability/v1.0">
+  <vosi:available>true</vosi:available>
+</vosi:availability>
+"""
+
+
+@pytest.mark.asyncio
+async def test_availability(client: AsyncClient) -> None:
+    r = await client.get("/test/availability")
+    assert r.status_code == 200
+    assert Availability.from_xml(r.text) == Availability.from_xml(AVAILABILITY)


### PR DESCRIPTION
Currently, the /availability route only uses UWS information, so it can be moved entirely into the UWS library. If this needs to be more complicated in the future, we can revisit it.

Use vo-cutouts for the Availability model and XML rendering instead of templating.