### PR TITLE
DM-45138: Refactor phase support for async jobs

### DIFF
--- a/changelog.d/20240715_155338_rra_DM_45138.md
+++ b/changelog.d/20240715_155338_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Restore support for automatically starting an async job by setting `phase=RUN` in the POST body. The equivalent query parameter was always supported, but POST body support was accidentally dropped in 3.0.0.

--- a/src/vocutouts/uws/handlers.py
+++ b/src/vocutouts/uws/handlers.py
@@ -25,6 +25,7 @@ from vo_models.uws.types import ExecutionPhase
 from .config import UWSRoute
 from .dependencies import (
     UWSFactory,
+    create_phase_dependency,
     runid_post_dependency,
     uws_dependency,
     uws_post_params_dependency,
@@ -524,7 +525,7 @@ def install_async_post_handler(router: APIRouter, route: UWSRoute) -> None:
         *,
         request: Request,
         phase: Annotated[
-            Literal["RUN"] | None, Query(title="Immediately start job")
+            Literal["RUN"] | None, Depends(create_phase_dependency)
         ] = None,
         parameters: Annotated[
             list[UWSJobParameter], Depends(route.dependency)

--- a/tests/uws/errors_test.py
+++ b/tests/uws/errors_test.py
@@ -144,5 +144,19 @@ async def test_errors(
         assert r.status_code == 422
         assert r.text.startswith("UsageError")
 
+    # Test bogus phase for async job creation.
+    r = await client.post(
+        "/test/jobs?phase=START",
+        headers={"X-Auth-Request-User": "user"},
+        data={"runid": "some-run-id", "name": "Jane"},
+    )
+    assert r.status_code == 422
+    r = await client.post(
+        "/test/jobs",
+        headers={"X-Auth-Request-User": "user"},
+        data={"runid": "some-run-id", "name": "Jane", "phase": "START"},
+    )
+    assert r.status_code == 422
+
     # None of these errors should have produced Slack errors.
     assert mock_slack.messages == []

--- a/tests/uws/job_api_test.py
+++ b/tests/uws/job_api_test.py
@@ -309,16 +309,10 @@ async def test_job_abort(
     r = await client.post(
         "/test/jobs",
         headers={"X-Auth-Request-User": "user"},
-        data={"runid": "some-run-id", "name": "Jane"},
+        data={"runid": "some-run-id", "name": "Jane", "phase": "RUN"},
     )
     assert r.status_code == 303
     assert r.headers["Location"] == "https://example.com/test/jobs/2"
-    r = await client.post(
-        "/test/jobs/2/phase",
-        headers={"X-Auth-Request-User": "user"},
-        data={"PHASE": "RUN"},
-    )
-    assert r.status_code == 303
     await runner.mark_in_progress("user", "2")
 
     # Abort that job.
@@ -571,21 +565,12 @@ async def test_presigned_url(
 
     # Create the job.
     r = await client.post(
-        "/test/jobs",
+        "/test/jobs?phase=RUN",
         headers={"X-Auth-Request-User": "user"},
         data={"runid": "some-run-id", "name": "Jane"},
     )
     assert r.status_code == 303
     job = await job_service.get("user", "1")
-
-    # Start the job.
-    r = await client.post(
-        "/test/jobs/1/phase",
-        headers={"X-Auth-Request-User": "user"},
-        data={"PHASE": "RUN"},
-        follow_redirects=True,
-    )
-    assert r.status_code == 200
     await runner.mark_in_progress("user", "1")
 
     # Tell the queue the job is finished, with an https URL.


### PR DESCRIPTION
Use a dependency that handles providing phase=RUN in either the query or the POST body, and restore support for the POST body parameter as well as its syntax checks. Add tests to ensure that this doesn't regress.