### PR TITLE
DM-45138: Abort jobs on deletion or expiration

### DIFF
--- a/changelog.d/20240715_164613_rra_DM_45138.md
+++ b/changelog.d/20240715_164613_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### New features
+
+- Abort jobs on deletion or expiration if they are pending, queued, or executing.

--- a/src/vocutouts/uws/models.py
+++ b/src/vocutouts/uws/models.py
@@ -173,6 +173,9 @@ class UWSJobDescription:
     job_id: str
     """Unique identifier of the job."""
 
+    message_id: str | None
+    """Internal message identifier for the work queuing system."""
+
     owner: str
     """Identity of the owner of the job."""
 

--- a/tests/support/uws.py
+++ b/tests/support/uws.py
@@ -10,7 +10,7 @@ from typing import Annotated, Self
 from arq.connections import RedisSettings
 from fastapi import Form, Query
 from pydantic import BaseModel, SecretStr
-from safir.arq import ArqMode, JobMetadata, MockArqQueue
+from safir.arq import ArqMode, JobMetadata, JobResult, MockArqQueue
 
 from vocutouts.uws.config import ParametersModel, UWSConfig, UWSRoute
 from vocutouts.uws.dependencies import UWSFactory
@@ -134,6 +134,23 @@ class MockJobRunner:
         job = await self._service.get(username, job_id)
         assert job.message_id
         return await self._arq.get_job_metadata(job.message_id)
+
+    async def get_job_result(self, username: str, job_id: str) -> JobResult:
+        """Get the arq job result for a job.
+
+        Parameters
+        ----------
+        job_id
+            UWS job ID.
+
+        Returns
+        -------
+        JobMetadata
+            arq job metadata.
+        """
+        job = await self._service.get(username, job_id)
+        assert job.message_id
+        return await self._arq.get_job_result(job.message_id)
 
     async def mark_in_progress(
         self, username: str, job_id: str, *, delay: float | None = None


### PR DESCRIPTION
Refactor expiration of jobs to log each job being expired and to abort the job if it is running. Also abort jobs if they are running when the job is deleted, and add a test for deletion of jobs via the POST method rather than the DELETE method.