### PR TITLE
DM-45138: Wait for jobs to finish before cancelling them

### DIFF
--- a/changelog.d/20240715_170552_rra_DM_45138.md
+++ b/changelog.d/20240715_170552_rra_DM_45138.md
@@ -1,0 +1,3 @@
+### New features
+
+- Worker pods now wait for 30 seconds (UWS database workers) or 55 seconds (cutout workers) for jobs to finish on shutdown before cancelling them.

--- a/src/vocutouts/config.py
+++ b/src/vocutouts/config.py
@@ -73,6 +73,15 @@ class Config(BaseSettings):
         None, title="Password for UWS job database"
     )
 
+    grace_period: timedelta = Field(
+        timedelta(seconds=30),
+        title="Grace period for jobs",
+        description=(
+            "How long to wait for a job to finish on shutdown before"
+            " canceling it"
+        ),
+    )
+
     lifetime: timedelta = Field(
         timedelta(days=7), title="Lifetime of cutout job results"
     )
@@ -194,12 +203,12 @@ class Config(BaseSettings):
         except ValueError:
             return parse_timedelta(v)
 
-    @field_validator("timeout", mode="before")
+    @field_validator("grace_period", "timeout", mode="before")
     @classmethod
     def _parse_timedelta_seconds(
         cls, v: str | float | timedelta
     ) -> float | timedelta:
-        """Support human-readable timedeltas."""
+        """Support number of seconds as a string."""
         if not isinstance(v, str):
             return v
         return int(v)

--- a/src/vocutouts/uws/app.py
+++ b/src/vocutouts/uws/app.py
@@ -115,6 +115,7 @@ class UWSApplication:
             ],
             functions=[uws_job_started, uws_job_completed],
             redis_settings=self._config.arq_redis_settings,
+            job_completion_wait=UWS_DATABASE_TIMEOUT,
             job_timeout=UWS_DATABASE_TIMEOUT,
             max_jobs=10,
             queue_name=UWS_QUEUE_NAME,

--- a/src/vocutouts/uws/constants.py
+++ b/src/vocutouts/uws/constants.py
@@ -21,7 +21,10 @@ JOB_STOP_TIMEOUT = timedelta(seconds=30)
 """How long to wait for a job to stop before giving up."""
 
 UWS_DATABASE_TIMEOUT = timedelta(seconds=30)
-"""Timeout on workers that update the UWS database."""
+"""Timeout on workers that update the UWS database.
+
+This should match the default Kubernetes grace period for a pod to shut down.
+"""
 
 UWS_EXPIRE_JOBS_SCHEDULE = Options(
     month=None,
@@ -35,4 +38,7 @@ UWS_EXPIRE_JOBS_SCHEDULE = Options(
 """Schedule for job expiration cron job, as `arq.cron.cron` parameters."""
 
 UWS_QUEUE_NAME = "uws:queue"
-"""Name of the arq queue for internal UWS messages."""
+"""Name of the arq queue for internal UWS messages.
+
+Must match ``_UWS_QUEUE_NAME`` in :mod:`vocutouts.uws.uwsworker`.
+"""

--- a/src/vocutouts/workers/cutout.py
+++ b/src/vocutouts/workers/cutout.py
@@ -195,12 +195,19 @@ configure_logging(
     log_level=os.getenv("CUTOUT_LOG_LEVEL", "INFO"),
 )
 
+# Provide five seconds of time for arq to shut the worker down cleanly after
+# cancelling any running job.
+_grace_period = timedelta(seconds=int(os.environ["CUTOUT_GRACE_PERIOD"]))
+if _grace_period > timedelta(seconds=5):
+    _grace_period -= timedelta(seconds=5)
+
 WorkerSettings = build_worker(
     cutout,
     WorkerConfig(
         arq_mode=ArqMode.production,
         arq_queue_url=os.environ["CUTOUT_ARQ_QUEUE_URL"],
         arq_queue_password=os.getenv("CUTOUT_ARQ_QUEUE_PASSWORD"),
+        grace_period=_grace_period,
         parameters_class=WorkerCutout,
         timeout=timedelta(seconds=int(os.environ["CUTOUT_TIMEOUT"])),
     ),


### PR DESCRIPTION
Wait for 30 seconds (UWS database workers) or 55 seconds (cutout workers) for jobs to finish before cancelling them. This should match settings on the Kubernetes pod to provide a shutdown grace period.