### PR TITLE
DM-45138: Move UWS queue name constant to worker module

### DIFF
--- a/src/vocutouts/uws/app.py
+++ b/src/vocutouts/uws/app.py
@@ -14,11 +14,7 @@ from structlog.stdlib import BoundLogger
 
 from . import schema
 from .config import UWSConfig
-from .constants import (
-    UWS_DATABASE_TIMEOUT,
-    UWS_EXPIRE_JOBS_SCHEDULE,
-    UWS_QUEUE_NAME,
-)
+from .constants import UWS_DATABASE_TIMEOUT, UWS_EXPIRE_JOBS_SCHEDULE
 from .exceptions import UWSError
 from .handlers import (
     install_async_post_handler,
@@ -27,7 +23,7 @@ from .handlers import (
     install_sync_post_handler,
     uws_router,
 )
-from .uwsworker import WorkerSettings
+from .uwsworker import UWS_QUEUE_NAME, WorkerSettings
 from .workers import (
     close_uws_worker_context,
     create_uws_worker_context,

--- a/src/vocutouts/uws/constants.py
+++ b/src/vocutouts/uws/constants.py
@@ -11,7 +11,6 @@ __all__ = [
     "JOB_RESULT_TIMEOUT",
     "UWS_DATABASE_TIMEOUT",
     "UWS_EXPIRE_JOBS_SCHEDULE",
-    "UWS_QUEUE_NAME",
 ]
 
 JOB_RESULT_TIMEOUT = timedelta(seconds=5)
@@ -36,9 +35,3 @@ UWS_EXPIRE_JOBS_SCHEDULE = Options(
     microsecond=0,
 )
 """Schedule for job expiration cron job, as `arq.cron.cron` parameters."""
-
-UWS_QUEUE_NAME = "uws:queue"
-"""Name of the arq queue for internal UWS messages.
-
-Must match ``_UWS_QUEUE_NAME`` in :mod:`vocutouts.uws.uwsworker`.
-"""

--- a/src/vocutouts/uws/uwsworker.py
+++ b/src/vocutouts/uws/uwsworker.py
@@ -28,11 +28,8 @@ from structlog.stdlib import BoundLogger
 T = TypeVar("T", bound="BaseModel")
 """Type for job parameters."""
 
-_UWS_QUEUE_NAME = "uws:queue"
-"""Name of the arq queue for internal UWS messages.
-
-Must match `~vocutouts.uws.constants.UWS_QUEUE_NAME`.
-"""
+UWS_QUEUE_NAME = "uws:queue"
+"""Name of the arq queue for internal UWS messages."""
 
 __all__ = [
     "WorkerConfig",
@@ -46,6 +43,7 @@ __all__ = [
     "WorkerTransientError",
     "WorkerUsageError",
     "T",
+    "UWS_QUEUE_NAME",
     "build_worker",
 ]
 
@@ -354,10 +352,10 @@ def build_worker(
         if config.arq_mode == ArqMode.production:
             settings = config.arq_redis_settings
             arq: ArqQueue = await RedisArqQueue.initialize(
-                settings, default_queue_name=_UWS_QUEUE_NAME
+                settings, default_queue_name=UWS_QUEUE_NAME
             )
         else:
-            arq = MockArqQueue(default_queue_name=_UWS_QUEUE_NAME)
+            arq = MockArqQueue(default_queue_name=UWS_QUEUE_NAME)
 
         ctx["arq"] = arq
         ctx["logger"] = logger

--- a/tests/uws/workers_test.py
+++ b/tests/uws/workers_test.py
@@ -20,11 +20,12 @@ from vo_models.uws.types import ErrorType, ExecutionPhase
 
 from vocutouts.uws.app import UWSApplication
 from vocutouts.uws.config import UWSConfig
-from vocutouts.uws.constants import UWS_DATABASE_TIMEOUT, UWS_QUEUE_NAME
+from vocutouts.uws.constants import UWS_DATABASE_TIMEOUT
 from vocutouts.uws.dependencies import UWSFactory
 from vocutouts.uws.models import ErrorCode, UWSJobParameter, UWSJobResult
 from vocutouts.uws.storage import JobStore
 from vocutouts.uws.uwsworker import (
+    UWS_QUEUE_NAME,
     WorkerConfig,
     WorkerFatalError,
     WorkerJobInfo,


### PR DESCRIPTION
To ensure that the worker module is isolated from the rest of the UWS code, move the constant that defines the database worker queue name to the uwsworker module out of constants.