### PR TITLE
DM-45138: Move PostgreSQL URL manipulation into type

### DIFF
--- a/tests/handlers/error_test.py
+++ b/tests/handlers/error_test.py
@@ -26,7 +26,7 @@ async def test_uncaught_error(
     errors in subapps.
     """
     engine = create_database_engine(
-        config.database_url, config.database_password
+        str(config.database_url), config.database_password
     )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)


### PR DESCRIPTION
Create a new EnvAsyncPostgresDsn type that modifies the URL based on environment variable settings set by tox-docker, avoiding the need for an explicit validator and making it easier to lift this code into Safir.

Due to a bug in the type system of Pydantic, this does not work in conjunction with the pattern to convert URLs into strings, so undo that change and keep the URL as a Pydantic MultiHostUrl object. This requires explicitly converting it to a string in a few places.