### PR TITLE
DM-45824: Re-add logging configuration for the backend worker

### DIFF
--- a/changelog.d/20240819_145310_rra_DM_45824.md
+++ b/changelog.d/20240819_145310_rra_DM_45824.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Restore logging configuration during startup of the backend worker, which re-adds support for the logging profile and log level and optionally configures structlog to use a JSON log format. This does not yet extend to the log messages issued directly by arq.

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -33,5 +33,6 @@ scons install declare -t current
 
 # Install Python dependencies and the vo-cutouts code.
 cd "$1"
-pip install --no-cache-dir google-cloud-storage httpx safir-arq structlog
+pip install --no-cache-dir \
+    google-cloud-storage httpx safir-arq safir-logging structlog
 pip install --no-cache-dir --no-deps .

--- a/src/vocutouts/workers/cutout.py
+++ b/src/vocutouts/workers/cutout.py
@@ -25,6 +25,7 @@ from safir.arq.uws import (
     WorkerUsageError,
     build_worker,
 )
+from safir.logging import configure_logging
 from structlog.stdlib import BoundLogger
 
 from ..models.domain.cutout import (
@@ -187,6 +188,12 @@ def cutout(
         )
     ]
 
+
+configure_logging(
+    name="vocutouts",
+    profile=os.getenv("CUTOUT_PROFILE", "development"),
+    log_level=os.getenv("CUTOUT_LOG_LEVEL", "INFO"),
+)
 
 # Provide five seconds of time for arq to shut the worker down cleanly after
 # cancelling any running job.


### PR DESCRIPTION
Now that saifr-logging is a separate PyPI project that we can depend on independent of the rest of Safir, add a safir-logging dependency to the backend worker and use `configure_logging` to set up logging during module import.