### PR TITLE
DM-47027: Change get param dependency to correctly parse list params

### DIFF
--- a/changelog.d/20241021_232057_steliosvoutsinas_DM_47027.md
+++ b/changelog.d/20241021_232057_steliosvoutsinas_DM_47027.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Bug fixes
+
+- Change get_params_dependency to fetch params using multi_items method

--- a/src/vocutouts/dependencies.py
+++ b/src/vocutouts/dependencies.py
@@ -67,7 +67,7 @@ async def get_params_dependency(
     """Parse GET parameters into job parameters for a cutout."""
     return [
         UWSJobParameter(parameter_id=k, value=v)
-        for k, v in request.query_params.items()
+        for k, v in request.query_params.multi_items()
         if k in {"id", "pos", "circle", "polygon"}
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,25 +4,50 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Iterator
 from datetime import timedelta
+from typing import Annotated
 
 import pytest
 import pytest_asyncio
 import respx
 import structlog
 from asgi_lifespan import LifespanManager
-from fastapi import FastAPI
+from fastapi import APIRouter, Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
 from safir.arq import MockArqQueue
 from safir.testing.gcs import MockStorageClient, patch_google_storage
 from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 from safir.testing.uws import MockUWSJobRunner
+from safir.uws import UWSJobParameter
 
 from vocutouts import main
 from vocutouts.config import config, uws
+from vocutouts.dependencies import get_params_dependency
+
+
+@pytest.fixture
+def get_params_router() -> APIRouter:
+    """Return a router that echoes the parameters passed to it."""
+    router = APIRouter()
+
+    @router.get("/params")
+    async def get_params(
+        params: Annotated[
+            list[UWSJobParameter], Depends(get_params_dependency)
+        ],
+    ) -> dict[str, list[dict[str, str]]]:
+        return {
+            "params": [
+                {"id": p.parameter_id, "value": p.value} for p in params
+            ]
+        }
+
+    return router
 
 
 @pytest_asyncio.fixture
-async def app(arq_queue: MockArqQueue) -> AsyncIterator[FastAPI]:
+async def app(
+    arq_queue: MockArqQueue, get_params_router: APIRouter
+) -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
     Initialize the database before creating the app to ensure that data is
@@ -35,6 +60,7 @@ async def app(arq_queue: MockArqQueue) -> AsyncIterator[FastAPI]:
         # Otherwise, the web application will use the one created in its
         # lifespan context manager.
         uws.override_arq_queue(arq_queue)
+        main.app.include_router(get_params_router)
         yield main.app
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ async def app(
         # Otherwise, the web application will use the one created in its
         # lifespan context manager.
         uws.override_arq_queue(arq_queue)
-        main.app.include_router(get_params_router)
+        main.app.include_router(get_params_router, prefix="/test")
         yield main.app
 
 

--- a/tests/handlers/sync_test.py
+++ b/tests/handlers/sync_test.py
@@ -88,7 +88,8 @@ async def test_bad_parameters(
 @pytest.mark.asyncio
 async def test_get_dependency_multiple_params(client: AsyncClient) -> None:
     response = await client.get(
-        "/params?id=image1&id=image2&pos=" "RANGE 10 20 30 40&circle=10 20 5"
+        "/test/params?id=image1&id=image2&pos="
+        "RANGE 10 20 30 40&circle=10 20 5"
     )
     assert response.status_code == 200
     assert response.json() == {

--- a/tests/handlers/sync_test.py
+++ b/tests/handlers/sync_test.py
@@ -83,3 +83,19 @@ async def test_bad_parameters(
 
     # None of these requests should have been reported to Slack.
     assert mock_slack.messages == []
+
+
+@pytest.mark.asyncio
+async def test_get_dependency_multiple_params(client: AsyncClient) -> None:
+    response = await client.get(
+        "/params?id=image1&id=image2&pos=" "RANGE 10 20 30 40&circle=10 20 5"
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        "params": [
+            {"id": "id", "value": "image1"},
+            {"id": "id", "value": "image2"},
+            {"id": "pos", "value": "RANGE 10 20 30 40"},
+            {"id": "circle", "value": "10 20 5"},
+        ]
+    }


### PR DESCRIPTION
**Summary**
GET & POST list params were not being read correctly, i.e. providing multiple "POS" params. Reason is that we were using 
request.query_params.items() instead of request.query_params.multi_items()
This fix has been tested and does now correctly read in list params.

**Tests**
A test case has been added which introduces a simple route that returns the params that were provided as a json response. 
Not sure if there is a better way to do this?