### PR TITLE
DM-47986: Catch errors from initializing Butler in worker

### DIFF
--- a/changelog.d/20241211_181509_rra_DM_47986.md
+++ b/changelog.d/20241211_181509_rra_DM_47986.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Catch errors from parsing the dataset ID or creating a Butler in the backend worker and report them as proper worker exceptions so that they don't produce uncaught exception errors.


### PR DESCRIPTION
In the backend worker, catch errors from parsing the dataset ID or from initializing Butler. Both can fail due to bad dataset IDs and previously those exceptions weren't being translated into worker exceptions and thus were being reported as uncaught exceptions and generic job failures. Now they will be correctly translated into usage or job failure errors.