### PR TITLE
DM-44669: Move image_cutout_backend inside lsst_distrib as dax_images_cutout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vo-cutouts
 
 vo-cutouts is a [FastAPI](https://fastapi.tiangolo.com/) web service and associated backend worker implementation that implements an image cutout service for the Rubin Science Platform.
-The underlying work of generating the cutout is delegated to [lsst.image_cutout_backend](https://github.com/lsst-dm/image_cutout_backend/).
+The underlying work of generating the cutout is delegated to [dax_images_cutout](https://github.com/lsst/dax_images_cutout/).
 
 See [CHANGELOG.md](https://github.com/lsst-sqre/vo-cutouts/blob/main/CHANGELOG.md) for the change history of vo-cutouts.
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -18,19 +18,6 @@ setup lsst_distrib
 # Display each command as it's run.
 set -x
 
-# Download the image cutout backend. This can be removed if RFC-828 is
-# implemented, since that will include the image cutout backend in
-# lsst-distrib.
-#
-# Currently, this uses the main branch because tags are not used regularly in
-# this repository.
-mkdir /backend
-cd /backend
-git clone --depth 1 -b main https://github.com/lsst-dm/image_cutout_backend.git
-cd image_cutout_backend
-setup -r .
-scons install declare -t current
-
 # Install Python dependencies and the vo-cutouts code.
 cd "$1"
 pip install --no-cache-dir \

--- a/scripts/start-worker.sh
+++ b/scripts/start-worker.sh
@@ -13,7 +13,6 @@ set -eo pipefail
 # Initialize the environment.
 source /opt/lsst/software/stack/loadLSST.bash
 setup lsst_distrib
-setup image_cutout_backend
 
 # Start Dramatiq with the worker.
 arq vocutouts.workers.cutout.WorkerSettings

--- a/src/vocutouts/workers/cutout.py
+++ b/src/vocutouts/workers/cutout.py
@@ -14,7 +14,7 @@ from uuid import UUID
 import structlog
 from lsst.afw.geom import SinglePolygonException
 from lsst.daf.butler import Butler, LabeledButlerFactory
-from lsst.dax.images.cutout import ImageCutoutBackend, projection_finders
+from lsst.dax.images.cutout import ImageCutoutFactory, projection_finders
 from lsst.dax.images.cutout.stencils import SkyCircle, SkyPolygon
 from safir.arq import ArqMode
 from safir.arq.uws import (
@@ -40,7 +40,7 @@ _BUTLER_FACTORY = LabeledButlerFactory()
 __all__ = ["WorkerSettings"]
 
 
-def _get_backend(butler_label: str, token: str) -> ImageCutoutBackend:
+def _get_backend(butler_label: str, token: str) -> ImageCutoutFactory:
     """Given the Butler label, retrieve or build a backend.
 
     The dataset ID will be a URI of the form ``butler://<label>/<uuid>``.
@@ -78,7 +78,7 @@ def _get_backend(butler_label: str, token: str) -> ImageCutoutBackend:
     projection_finder = projection_finders.ProjectionFinder.make_default()
     output = os.environ["CUTOUT_STORAGE_URL"]
     tmpdir = os.environ.get("CUTOUT_TMPDIR", "/tmp")
-    return ImageCutoutBackend(butler, projection_finder, output, tmpdir)
+    return ImageCutoutFactory(butler, projection_finder, output, tmpdir)
 
 
 def _parse_uri(uri: str) -> tuple[str, UUID]:

--- a/src/vocutouts/workers/cutout.py
+++ b/src/vocutouts/workers/cutout.py
@@ -14,8 +14,8 @@ from uuid import UUID
 import structlog
 from lsst.afw.geom import SinglePolygonException
 from lsst.daf.butler import Butler, LabeledButlerFactory
-from lsst.image_cutout_backend import ImageCutoutBackend, projection_finders
-from lsst.image_cutout_backend.stencils import SkyCircle, SkyPolygon
+from lsst.dax.images.cutout import ImageCutoutBackend, projection_finders
+from lsst.dax.images.cutout.stencils import SkyCircle, SkyPolygon
 from safir.arq import ArqMode
 from safir.arq.uws import (
     WorkerConfig,
@@ -56,7 +56,7 @@ def _get_backend(butler_label: str, token: str) -> ImageCutoutBackend:
 
     Returns
     -------
-    lsst.image_cutout_backend.ImageCutoutBackend
+    lsst.dax.images.cutout.ImageCutoutBackend
         Backend to use.
 
     Raises


### PR DESCRIPTION
Fix the python import to use the new name and no longer attempt to clone and separately install the cutout code.