### PR TITLE
DM-49075: Use new type syntax for type aliases

### DIFF
--- a/src/vocutouts/models/cutout.py
+++ b/src/vocutouts/models/cutout.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from itertools import batched
-from typing import Annotated, Literal, Self, TypeAlias
+from typing import Annotated, Literal, Self
 
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -194,7 +194,7 @@ class RangeStencil(Stencil):
         )
 
 
-StencilType: TypeAlias = Annotated[
+type StencilType = Annotated[
     CircleStencil | PolygonStencil | RangeStencil, Field(discriminator="type")
 ]
 """Type for any stencil, concrete due to Pydantic requirements."""

--- a/src/vocutouts/models/domain/cutout.py
+++ b/src/vocutouts/models/domain/cutout.py
@@ -59,21 +59,21 @@ def _deserialize_sky_coord(c: Any) -> SkyCoord:
         return SkyCoord(c[0] * u.degree, c[1] * u.degree, frame="icrs")
 
 
-AngleSerializable = Annotated[
+type AngleSerializable = Annotated[
     Angle,
     BeforeValidator(_deserialize_angle),
     PlainSerializer(lambda x: float(x.degree), return_type=float),
 ]
 """Angle with serialization support."""
 
-SkyCoordSerializable = Annotated[
+type SkyCoordSerializable = Annotated[
     SkyCoord,
     BeforeValidator(_deserialize_sky_coord),
     PlainSerializer(_serialize_sky_coord),
 ]
 """Sky coordinate with serialization support."""
 
-WorkerRange: TypeAlias = tuple[float, float]
+type WorkerRange = tuple[float, float]
 """Type representing a range of a coordinate."""
 
 


### PR DESCRIPTION
Use the new `type` keyword instead of `TypeAlias` when creating new types.