### PR TITLE
DM-49075: Replace AsyncIterator with AsyncGenerator

### DIFF
--- a/src/vocutouts/main.py
+++ b/src/vocutouts/main.py
@@ -7,7 +7,7 @@ constructed when this module is loaded and is not deferred until a function is
 called.
 """
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version
 
@@ -26,7 +26,7 @@ __all__ = ["app"]
 
 
 @asynccontextmanager
-async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Set up and tear down the application."""
     await uws.initialize_fastapi()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncGenerator, Iterator
 from datetime import timedelta
 
 import pytest
@@ -23,7 +23,7 @@ from vocutouts.config import config, uws
 @pytest_asyncio.fixture
 async def app(
     arq_queue: MockArqQueue, mock_wobbly: MockWobbly
-) -> AsyncIterator[FastAPI]:
+) -> AsyncGenerator[FastAPI]:
     """Return a configured test application."""
     async with LifespanManager(main.app):
         # Ensure that all the components use the same mock arq queue.
@@ -41,7 +41,7 @@ def arq_queue() -> MockArqQueue:
 @pytest_asyncio.fixture
 async def client(
     app: FastAPI, test_token: str, test_username: str
-) -> AsyncIterator[AsyncClient]:
+) -> AsyncGenerator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         transport=ASGITransport(app=app),


### PR DESCRIPTION
Where an async iterator is provided via a generator, declare the return type to be the more accurate `AsyncGenerator`.