### PR TITLE
DM-49075: Prepare 4.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-4.1.0'></a>
+## 4.1.0 (2025-02-20)
+
+### New features
+
+- Replace internal Butler URI parsing with calls into the Butler library. This adds support for the new Butler URI format that will be used for future data releases.
+
+### Other changes
+
+- Use the cutout backend code that is integrated into the stack container rather than installing code from Git during container build time.
+
 <a id='changelog-4.0.0'></a>
 ## 4.0.0 (2024-12-12)
 

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -27,6 +27,7 @@ docstring-code-format = true
 
 [lint]
 ignore = [
+    "A005",     # we always use relative imports so this is not ambiguous
     "ANN401",   # sometimes Any is the right type
     "ARG001",   # unused function arguments are often legitimate
     "ARG002",   # unused method arguments are often legitimate


### PR DESCRIPTION
Update the shared Ruff configuration file. Write a change log entry for 4.1.0.