### PR TITLE
DM-51420: Switch to PEP 639 license information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,13 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "vo-cutouts"
 description = "Image cutout service for the Rubin Science Platform."
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 keywords = ["rubin", "lsst"]
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Use the new `pyproject.toml` fields for license information and remove the classifier.