### PR TITLE
DM-51420: Use cache file system for Docker apt actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ FROM python:3.13.5-slim-bookworm AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
-RUN ./install-base-packages.sh && rm ./install-base-packages.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    ./install-base-packages.sh && rm ./install-base-packages.sh
 
 FROM base-image AS install-image
 
@@ -25,7 +27,9 @@ COPY --from=ghcr.io/astral-sh/uv:0.5.8 /uv /bin/uv
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .
-RUN ./install-dependency-packages.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    ./install-dependency-packages.sh
 
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -26,7 +26,3 @@ apt-get -y upgrade
 
 # Install dependencies required at runtime (none currently).
 #apt-get -y install --no-install-recommends
-
-# Delete cached files we don't need anymore.
-apt-get clean
-rm -rf /var/lib/apt/lists/*

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -28,7 +28,3 @@ apt-get update
 # git: required by setuptools_scm
 # libffi-dev: sometimes needed to build cffi, a cryptography dependency
 apt-get -y install --no-install-recommends build-essential git libffi-dev
-
-# Delete cached files we don't need anymore:
-apt-get clean
-rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
When upgrading and installing packages, use the Docker cache file system to hold the apt cache and lists. This removes the need to explicitly clean up the lists after installation.