### PR TITLE
DM-51420: Update to released v29.1.0 Pipelines stack

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, arq, and the backend worker definition.
 
-FROM ghcr.io/lsst/scipipe:al9-v29_1_0_rc4
+FROM ghcr.io/lsst/scipipe:al9-v29_1_0
 
 # Reset the user to root since we need to do system install tasks.
 USER root


### PR DESCRIPTION
Update the base image for the cutouts worker to the released v29.1.0 version of the Pipelines stack container.