### PR TITLE
DM-51504: Update the base image for the cutout worker

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, arq, and the backend worker definition.
 
-FROM ghcr.io/lsst/scipipe:al9-v29_1_0
+FROM ghcr.io/lsst/scipipe:al9-v29_1_1
 
 # Reset the user to root since we need to do system install tasks.
 USER root

--- a/changelog.d/20250623_135551_rra_DM_51504.md
+++ b/changelog.d/20250623_135551_rra_DM_51504.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Update the worker image to the latest Pipelines stack release (`v29_1_1`).


### PR DESCRIPTION
Update to v21.1.1, which has some additional fixes over the v21.1.0 release.