### PR TITLE
DM-52310: Update to the 29.2.0 Science Pipelines container

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, arq, and the backend worker definition.
 
-FROM ghcr.io/lsst/scipipe:al9-v29_1_1
+FROM ghcr.io/lsst/scipipe:al9-v29_2_0
 
 # Reset the user to root since we need to do system install tasks.
 USER root

--- a/changelog.d/20250825_161605_rra_DM_52310.md
+++ b/changelog.d/20250825_161605_rra_DM_52310.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Update the backend to the 29.2.0 release of the Science Pipelines, which will hopefully fix a memory leak.


### PR DESCRIPTION
Update the backend to the 29.2.0 release of the Science Pipelines, which will hopefully fix a memory leak.