### PR TITLE
DM-55210: The newer cutout service raises a non-afw exception for stencil mismatch

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # are based on stack containers and install any required supporting code
 # for the image cutout backend, arq, and the backend worker definition.
 
-FROM ghcr.io/lsst/scipipe:al9-w_2025_41
+FROM ghcr.io/lsst/scipipe:al9-w_2026_26
 
 # Reset the user to root since we need to do system install tasks.
 USER root

--- a/src/vocutouts/workers/cutout.py
+++ b/src/vocutouts/workers/cutout.py
@@ -10,14 +10,17 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 import structlog
-from lsst.afw.geom import SinglePolygonException
 from lsst.daf.butler import Butler, LabeledButlerFactory
 from lsst.dax.images.cutout import (
     CutoutMode,
     ImageCutoutFactory,
     projection_finders,
 )
-from lsst.dax.images.cutout.stencils import SkyCircle, SkyPolygon
+from lsst.dax.images.cutout.stencils import (
+    SkyCircle,
+    SkyPolygon,
+    StencilNotContainedError,
+)
 from safir.arq import ArqMode
 from safir.arq.uws import (
     WorkerConfig,
@@ -229,7 +232,7 @@ def cutout(
         result = backend.process_uuid(
             sky_stencils[0], uuid, mask_plane=None, cutout_mode=cutout_mode
         )
-    except SinglePolygonException as e:
+    except StencilNotContainedError as e:
         raise WorkerUsageError(
             "No intersection between cutout and image", add_traceback=True
         ) from e


### PR DESCRIPTION
StencilNotContainedError is the new exception. dax_images_cutout no longer uses afw for this validation and only uses afw at all for DP1 cutouts.

@rra what I'm not sure about is whether you are going to want this code to work with older weeklies (so would need to protect the new import and keep the afw one) or if we can decide that this version of the code requires a newer weekly. If we could drop DP1 we would not need pipelines at all and could pip install everything (but we do have to support DP1 for now).