### PR TITLE
DM-55358: Add job to clean up Docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,9 +41,12 @@ jobs:
         run: uv run --only-group=tox tox run -e lint,typing,py,coverage-report
 
   build:
+    concurrency:
+      group: packages
+      queue: max
     needs: [test]
-    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     secrets: inherit
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       images: ghcr.io/${{ github.repository }}
 
@@ -59,9 +62,12 @@ jobs:
               || startsWith(github.head_ref, 't/')))
 
   build-worker:
+    concurrency:
+      group: packages
+      queue: max
     needs: [test]
-    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     secrets: inherit
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       dockerfile: Dockerfile.worker
       images: ghcr.io/${{ github.repository }}-worker

--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -1,0 +1,28 @@
+# Prune unreferenced Docker images and ticket branches from more than six
+# months ago, weekly on Monday.
+
+name: GHCR Cleanup
+
+"on":
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    concurrency:
+      group: packages
+      queue: max
+
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-orphaned-images: true
+          delete-tags: "tickets-*,t-*"
+          delete-untagged: true
+          dry-run: true
+          older-than: "6 months"
+          validate: true


### PR DESCRIPTION
Periodically delete old ticket branch tagged images and any orphaned images or unreferenced images. Add a concurrency group to ensure that the cleanup job does not run at the same time as new Docker builds.