### PR TITLE
DM-55358: Remove dry run on GHCR cleanup job

### DIFF
--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -24,4 +24,5 @@ jobs:
           delete-tags: "tickets-*,t-*"
           delete-untagged: true
           older-than: "6 months"
+          packages: vo-cutouts,vo-cutouts-worker
           validate: true

--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -23,6 +23,5 @@ jobs:
           delete-orphaned-images: true
           delete-tags: "tickets-*,t-*"
           delete-untagged: true
-          dry-run: true
           older-than: "6 months"
           validate: true


### PR DESCRIPTION
This appears to be doing the right thing, so allow it to run for real.