### PR TITLE
DM-55490: Use granular concurrency groups for cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
 
   build:
     concurrency:
-      group: packages
+      group: docker
       queue: max
     needs: [test]
     secrets: inherit
@@ -63,7 +63,7 @@ jobs:
 
   build-worker:
     concurrency:
-      group: packages
+      group: docker-worker
       queue: max
     needs: [test]
     secrets: inherit

--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       packages: write
     concurrency:
-      group: packages
+      group: docker
       queue: max
 
     steps:
@@ -24,5 +24,23 @@ jobs:
           delete-tags: "tickets-*,t-*"
           delete-untagged: true
           older-than: "6 months"
-          packages: vo-cutouts,vo-cutouts-worker
+          packages: vo-cutouts
+          validate: true
+
+  cleanup-worker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    concurrency:
+      group: docker-worker
+      queue: max
+
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-orphaned-images: true
+          delete-tags: "tickets-*,t-*"
+          delete-untagged: true
+          older-than: "6 months"
+          packages: vo-cutouts-worker
           validate: true


### PR DESCRIPTION
Use separate concurrency groups for the frontend and worker Docker builds and separate GHCR cleanup jobs, which ensures that the build of the frontend doesn't block the build of the worker and vice versa.